### PR TITLE
Object viewer, Toolbar, Async Requests, and Schema Rendering

### DIFF
--- a/docker/tranql-base/requirements.txt
+++ b/docker/tranql-base/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp==3.5.4
 aniso8601==4.1.0
 appnope==0.1.0
 atomicwrites==1.3.0

--- a/tranql/api.py
+++ b/tranql/api.py
@@ -145,7 +145,7 @@ class TranQLQuery(StandardAPIResource):
 
     def __init__(self):
         super().__init__()
-        
+
     def post(self):
         """
         query
@@ -181,7 +181,7 @@ class TranQLQuery(StandardAPIResource):
         #self.validate (request)
         result = {}
         try:
-            tranql = TranQL ()
+            tranql = TranQL (asynchronous=False)
             logging.debug (request.json)
             query = request.json['query'] if 'query' in request.json else ''
             logging.debug (f"----------> query: {query}")
@@ -208,7 +208,7 @@ class ModelConceptsQuery(StandardAPIResource):
 
     def __init__(self):
         super().__init__()
-        
+
     def post(self):
         """
         query
@@ -252,7 +252,7 @@ class ModelRelationsQuery(StandardAPIResource):
 
     def __init__(self):
         super().__init__()
-        
+
     def post(self):
         """
         query

--- a/tranql/api.py
+++ b/tranql/api.py
@@ -18,6 +18,7 @@ from tranql.concept import ConceptModel
 from tranql.main import TranQL
 import networkx as nx
 from tranql.util import JSONKit
+from tranql.tranql_schema import GraphTranslator, Schema
 from tranql.concept import BiolinkModelWalker
 from tranql.exception import TranQLException
 #import flask_monitoringdashboard as dashboard
@@ -181,7 +182,7 @@ class TranQLQuery(StandardAPIResource):
         #self.validate (request)
         result = {}
         try:
-            tranql = TranQL (asynchronous=False)
+            tranql = TranQL ()
             logging.debug (request.json)
             query = request.json['query'] if 'query' in request.json else ''
             logging.debug (f"----------> query: {query}")
@@ -202,6 +203,38 @@ class TranQLQuery(StandardAPIResource):
                 "details" : ''
             }
         return result
+
+class SchemaGraph(StandardAPIResource):
+    """ Graph of schema to display to the client """
+
+    def __init__(self):
+        super().__init__()
+
+    def get(self):
+        """
+        responses:
+            '200':
+                description: Success
+                content:
+                    text/plain:
+                        schema:
+                            type: string
+            '400':
+                description: Malformed message
+                content:
+                    text/plain:
+                        schema:
+                            type: string
+        """
+        tranql = TranQL ()
+        schema = Schema (backplane=tranql.context.mem.get('backplane'))
+        schemaGraph = GraphTranslator(schema.schema_graph)
+
+        # logger.info(schema.schema_graph.net.nodes)
+        # logger.info(schemaGraph.graph_to_message())
+
+        # return {"nodes":[],"links":[]}
+        return schemaGraph.graph_to_message()
 
 class ModelConceptsQuery(StandardAPIResource):
     """ Query model concepts. """
@@ -297,6 +330,7 @@ class ModelRelationsQuery(StandardAPIResource):
 ###############################################################################################
 
 api.add_resource(TranQLQuery, '/tranql/query')
+api.add_resource(SchemaGraph, '/tranql/schema')
 api.add_resource(ModelConceptsQuery, '/tranql/model/concepts')
 api.add_resource(ModelRelationsQuery, '/tranql/model/relations')
 

--- a/tranql/conf.yml
+++ b/tranql/conf.yml
@@ -1,2 +1,3 @@
 ---
 BACKPLANE: http://localhost:8099
+ASYNCHRONOUS_REQUESTS: true

--- a/tranql/main.py
+++ b/tranql/main.py
@@ -91,7 +91,7 @@ realNum = ppc.real()
 intNum = ppc.signed_integer()
 
 # need to add support for alg expressions
-columnRval = realNum | intNum | quotedString.addParseAction(removeQuotes) | columnName 
+columnRval = realNum | intNum | quotedString.addParseAction(removeQuotes) | columnName
 whereCondition = Group(
     ( columnName + binop + (columnRval | Word(printables) ) ) |
     ( columnName + in_ + "(" + delimitedList( columnRval ) + ")" ) |
@@ -114,9 +114,9 @@ optWhite = ZeroOrMore(LineEnd() | White())
 """ Define the statement grammar. """
 statement <<= (
     Group(
-        Group(SELECT + question_graph_expression)("concepts") + optWhite + 
-        Group(FROM + tableNameList) + optWhite + 
-        Group(Optional(WHERE + whereExpression("where"), "")) + optWhite + 
+        Group(SELECT + question_graph_expression)("concepts") + optWhite +
+        Group(FROM + tableNameList) + optWhite +
+        Group(Optional(WHERE + whereExpression("where"), "")) + optWhite +
         Group(Optional(SET + setExpression("set"), ""))("select")
     )
     |
@@ -140,7 +140,7 @@ program_grammar = statement + ZeroOrMore(statement)
 """ Make rest-of-line comments. """
 comment = "--" + restOfLine
 program_grammar.ignore (comment)
-        
+
 class TranQLParser:
     """ Defines the language's grammar. """
     def __init__(self, backplane):
@@ -150,16 +150,16 @@ class TranQLParser:
         """ Parse a program, returning an abstract syntax tree. """
         result = self.program.parseString (line)
         return TranQL_AST (result.asList (), self.backplane)
-        
+
 class TranQL:
     """
-    Define the language interpreter. 
+    Define the language interpreter.
     It provides an interface to
       Execute the parser
       Generate an abstract syntax tree
       Execute statements in the abstract syntax tree.
     """
-    def __init__(self, backplane="http://localhost:8099"):
+    def __init__(self, backplane="http://localhost:8099", asynchronous=True):
         """ Initialize the interpreter. """
         self.context = Context ()
         config_path = "conf.yml"
@@ -174,7 +174,9 @@ class TranQL:
             backplane = env_backplane
         self.context.set ("backplane", backplane)
         self.parser = TranQLParser (backplane)
-        
+
+        self.asynchronous = asynchronous
+
     def parse (self, program):
         """ If we just want the AST. """
         return self.parser.parse (program)
@@ -184,7 +186,7 @@ class TranQL:
         with open(file_name, "r") as stream:
             result = self.parse (stream.read ())
         return result
-    
+
     def execute (self, program, cache=False):
         """ Execute a program - a list of statements. """
         ast = None
@@ -193,7 +195,7 @@ class TranQL:
                                          allowable_methods=('GET', 'POST', ))
         else:
             requests_cache.disabled()
-            
+
         if isinstance(program, str):
             ast = self.parse (program)
         if not ast:
@@ -221,15 +223,15 @@ class TranQL:
             for t in term:
                 result.update ({ x : self.context.mem[x] for x in list(self.context.mem.keys ()) if x.lower().startswith (t) })
         else:
-            result = { x : self.context.mem[x] for x in list(self.context.mem.keys ()) if x.lower().startswith (term) } 
+            result = { x : self.context.mem[x] for x in list(self.context.mem.keys ()) if x.lower().startswith (term) }
         return result
-    
+
     def shell (self):
         """ Read, Eval, Print Loop. """
         header = """
-  ______                 ____    __ 
- /_  __/________ _____  / __ \  / / 
-  / / / ___/ __ `/ __ \/ / / / / /  
+  ______                 ____    __
+ /_  __/________ _____  / __ \  / /
+  / / / ___/ __ `/ __ \/ / / / / /
  / / / /  / /_/ / / / / /_/ / / /___
 /_/ /_/   \__,_/_/ /_/\___\_\/_____/
                                      v0.1"""
@@ -270,7 +272,7 @@ def set_verbose ():
     for logger_name in [ "tranql.main", "tranql.tranql_ast", "tranql.util" ]:
         logger = logging.getLogger (logger_name)
         logger.setLevel (logging.DEBUG)
-        
+
 def main ():
     """ Process arguments. """
     arg_parser = argparse.ArgumentParser(
@@ -291,6 +293,8 @@ def main ():
     arg_parser.add_argument('-o', '--output', help="Output destination")
     arg_parser.add_argument('-a', '--arg', help="Output destination",
                             action="append", default=[])
+    # -x is placeholder as '-a' taken; should eventually replace with better fitting letter
+    arg_parser.add_argument('-x', '--asynchronous', default=False, help="Run requests asynchronously with asyncio")
     args = arg_parser.parse_args ()
 
     global logger
@@ -306,7 +310,7 @@ def main ():
                                      allowable_methods=('GET', 'POST', ))
 
     """ Create an interpreter. """
-    tranql = TranQL (backplane = args.backplane)
+    tranql = TranQL (backplane = args.backplane, asynchronous = args.asynchronous)
     for k, v in query_args.items ():
         logger.debug (f"setting {k}={v}")
         tranql.context.set (k, v)
@@ -322,7 +326,6 @@ def main ():
             print (f"top-gene: {json.dumps(context.top('gene',k='chemical_pathways'), indent=2)}")
     else:
         print ("Either source or shell must be specified")
-        
-if __name__ == '__main__':    
+
+if __name__ == '__main__':
     main ()
-    

--- a/tranql/main.py
+++ b/tranql/main.py
@@ -175,6 +175,9 @@ class TranQL:
         self.context.set ("backplane", backplane)
         self.parser = TranQLParser (backplane)
 
+        if 'ASYNCHRONOUS_REQUESTS' in self.config:
+            asynchronous = self.config['ASYNCHRONOUS_REQUESTS']
+
         self.asynchronous = asynchronous
 
     def parse (self, program):

--- a/tranql/request_util.py
+++ b/tranql/request_util.py
@@ -1,0 +1,144 @@
+import asyncio
+import logging
+from aiohttp import ClientSession
+from time import time as now
+from tranql.exception import ServiceInvocationError
+
+async def make_request_async (semaphore, **kwargs):
+    response = {}
+    unknown_service = False
+    try:
+        async with ClientSession () as session:
+            async with session.request (**kwargs) as http_response:
+                # print(f"[{kwargs['method'].upper()}] requesting at url: {kwargs['url']}")
+                """ Check status and handle response. """
+                if http_response.status == 200 or http_response.status == 202:
+                    response = await http_response.json ()
+                    #logger.error (f" response: {json.dumps(response, indent=2)}")
+                    status = response.get('status', None)
+                    if status == "error":
+                        raise ServiceInvocationError(
+                            message=f"An error occurred invoking service: {kwargs['url']}.",
+                            details=response['message'])
+                elif http_response.status == 404:
+                    unknown_service = True
+                else:
+                    pass
+                    # logger.error (f"error {http_response.status} processing request: {message}")
+                    # logger.error (http_response.text)
+    except ServiceInvocationError as e:
+        raise e
+    except Exception as e:
+        raise e
+        # logger.error (f"error performing request: {json.dumps(message, indent=2)} to url: {url}")
+        #traceback.print_exc ()
+        # logger.error (traceback.format_exc ())
+    if unknown_service:
+        raise UnknownServiceError (f"Service {url} was not found. Is it misspelled?")
+    return response
+
+"""
+Concurrently makes all requests from a given pool of requests
+
+Args:
+    requestPool (dict[]): List of **kwarg dictionaries. Keyword arguments will be passed directly to the requests.request call
+        Ex: {"method":"post","url":url} => requests.request(method="post",url=url)
+    maxRequests (int, optional): Maximum number of requests that may be executing at any given time
+
+Returns:
+    List of returned responses
+"""
+def async_make_requests (requestPool, maxRequests=3):
+
+    # Duck test approach
+    try:
+        loop = asyncio.get_event_loop ()
+
+    except RuntimeError:
+        loop = asyncio.new_event_loop ()
+        asyncio.set_event_loop (loop)
+
+
+    semaphore = asyncio.BoundedSemaphore (maxRequests)
+
+    # tasks = asyncio.gather (*[make_request (**request) for request in requestPool])
+
+    tasks = asyncio.gather(*[(make_request_async (semaphore, **request)) for request in requestPool])
+
+    # for request in requestPool:
+        # tasks.append (asyncio.ensure_future (make_request (semaphore, **request)))
+
+    results = loop.run_until_complete(tasks)
+
+    return results
+
+if __name__ == "__main__":
+    reqs = [
+        *[
+            {
+                "method" : "get",
+                "url": "https://jsonplaceholder.typicode.com/todos/1",
+                "json": {},
+                "headers": {
+                    'accept': 'application/json'
+                }
+            }
+            for i in range(15)
+        ]
+    ]
+
+    # Profile time to make all requests asynchronously
+    time = now()
+    print ("ASYNC REQUESTS:", async_make_requests(reqs))
+    # async_make_requests (reqs, 1000)
+    print (f"TIME TO COMPLETE {len(reqs)} REQUESTS ASYNCHRONOUSLY:", now() - time)
+
+    import requests
+    def make_request_sync (**kwargs):
+        response = {}
+        unknown_service = False
+        try:
+            http_response = requests.request (**kwargs)
+            """ Check status and handle response. """
+            if http_response.status_code == 200 or http_response.status_code == 202:
+                response = http_response.json ()
+                #logger.error (f" response: {json.dumps(response, indent=2)}")
+                status = response.get('status', None)
+                if status == "error":
+                    raise ServiceInvocationError(
+                        message=f"An error occurred invoking service: {url}.",
+                        details=truncate(response['message'], max_length=5000))
+            elif http_response.status_code == 404:
+                unknown_service = True
+            else:
+                pass
+                # logger.error (f"error {http_response.status_code} processing request: {message}")
+                # logger.error (http_response.text)
+        except ServiceInvocationError as e:
+            raise e
+        except Exception as e:
+            print (e)
+            # logger.error (f"error performing request: {json.dumps(message, indent=2)} to url: {url}")
+            #traceback.print_exc ()
+            # logger.error (traceback.format_exc ())
+        if unknown_service:
+            raise UnknownServiceError (f"Service {url} was not found. Is it misspelled?")
+        return response
+
+    # Profile time to make all requests synchronously
+    time = now()
+    results = []
+    for request in reqs:
+        results.append (make_request_sync (**request))
+    print ("SYNC REQUESTS:", results)
+    print (f"TIME TO COMPLETE {len(reqs)} REQUESTS SYNCHRONOUSLY:", now() - time)
+
+
+
+
+
+
+
+
+
+#

--- a/tranql/requirements.txt
+++ b/tranql/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp==3.5.4
 aniso8601==4.1.0
 appnope==0.1.0
 atomicwrites==1.3.0

--- a/tranql/tests/test_tranql.py
+++ b/tranql/tests/test_tranql.py
@@ -478,7 +478,7 @@ def test_interpreter_set (requests_mock):
 def test_program (requests_mock):
     print ("test_program ()")
     mock_map = MockMap (requests_mock, "workflow-5")
-    tranql = TranQL ()
+    tranql = TranQL (asynchronous=False)
     ast = tranql.execute ("""
     --
     -- Workflow 5

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^16.8.4",
     "react-force-graph": "^1.20.5",
     "react-icons": "^3.5.0",
+    "react-json-tree": "^0.11.2",
     "react-json-view": "^1.19.1",
     "react-modal": "^3.8.1",
     "react-scripts": "^2.1.8",

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -193,7 +193,7 @@
   /* right : 3px; */
   /* top: 40px; */
 }
-#mainLegend {
+.Legend {
   border-top:1px solid rgb(200,200,200);
   border-bottom:1px solid rgb(200,200,200);
 }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -49,23 +49,30 @@
 #schemaBanner {
     background-color: rgb(30, 30, 30);
     border-bottom: 4px solid rgb(50, 50, 50);
-    /* font-weight: bold; */
     position: relative;
-    padding: 12.5px;
+    padding: 10px;
     /* text-align: center; */
+    /* text-decoration: underline; */
+    font-weight: bold;
     font-style: italic;
     font-size: 18px;
     color: rgb(235, 235, 235);
+    display:flex;
+    align-items: center;
+}
+.fa-spin {
+  /* Pseudo fa-spin class because react-icons doesn't seem to natively support it */
+  -ms-animation:spin 2s linear infinite;
+  -o-animation:spin 2s linear infinite;
+  -webkit-animation:spin 2s linear infinite;
+  -moz-animation:spin 2s linear infinite;
+  animation:spin 2s linear infinite;
 }
 #schemaViewToggleButtonContainer {
-  height:100%;
-  float:right;
-  /* top:0; */
-  /* right:12.5px; */
-  /* position:absolute; */
-  display:flex;
-  justify-content:center;
-  align-items:center;
+  flex-grow: 1;
+}
+#schemaViewToggleButton {
+  float: right;
 }
 #info {
     /* position: absolute; */
@@ -275,3 +282,9 @@
     .Resizer.disabled:hover {
       border-color: transparent;
     }
+
+@-ms-keyframes spin { 100% { -moz-transform: rotate(360deg); } }
+@-o-keyframes spin { 100% { -moz-transform: rotate(360deg); } }
+@-moz-keyframes spin { 100% { -moz-transform: rotate(360deg); } }
+@-webkit-keyframes spin { 100% { -webkit-transform: rotate(360deg); } }
+@keyframes spin { 100% { -webkit-transform: rotate(360deg); transform:rotate(360deg); } }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -24,18 +24,37 @@
     height : 100%;
     width : 100%;
 }
+#viewContainer {
+    display:flex;
+    height:100%;
+    width:100%;
+    position:absolute;
+}
+#viewContainer > .SplitPane {
+    flex:1 !important;
+}
+#toolbar {
+    background-color:rgba(39, 40, 34, 1);
+    border-right:2px solid rgb(80, 86, 70);
+    width:auto;
+}
 #info {
     /* position: absolute; */
     background-color: rgb(39, 40, 34);
     /* bottom: 0px; */
     overflow:auto;
     height:100%;
+    width:100%;
     border-left: 2px solid rgb(166, 226, 46);
 
 }
 #info > ul {
-  margin:5px !important;
-  margin-bottom: 12.5px !important;
+    margin:5px !important;
+    margin-bottom: 12.5px !important;
+}
+
+.Resizer.disabled {
+  cursor:auto !important;
 }
 
 .tableView {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -130,6 +130,10 @@
     margin-left : 5px;
     margin-right : 5px;
 }
+.App-control-toolbar {
+  font-size: 22px;
+  color: rgba(220,220,220,.9);
+}
 .answerNavigator {
     width: 95%;
     height: 95%;
@@ -162,8 +166,6 @@
     float: right;
 }
 #navModeButton {
-    position: absolute;
-    right: 105px;
 }
 #runButton {
   height:60%;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -34,7 +34,7 @@
     flex:1 !important;
 }
 #toolbar {
-    background-color:rgba(39, 40, 34, 1);
+    background-color:rgba(30,30,30, 1);
     width:auto;
 }
 #info {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -25,16 +25,18 @@
     width : 100%;
 }
 #info {
-    position: absolute;
-    background-color: white;
-    text-align: left;
-    bottom: 0px;
-    width: 100%;
-    height: 100px;
-    color: aliceblue;
-    border-top: 2px solid lightblue;
-    display: none;
+    /* position: absolute; */
+    background-color: rgb(39, 40, 34);
+    /* bottom: 0px; */
+    overflow:auto;
+    height:100%;
+    border-left: 2px solid rgb(60,60,60);
+
 }
+#info > ul {
+  margin:5px !important;
+}
+
 .tableView {
     position : absolute;
     bottom : 0px;
@@ -43,9 +45,9 @@
     border-top: 2px solid lightblue;
  }
 .react-json-view {
+    height:100%;
     position: absolute;
-    overflow: scroll;
-    height: 100px;
+    overflow: auto;
  }
 .App-logo {
     /*animation: App-logo-spin infinite 20s linear; */

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -9,6 +9,15 @@
      width: 100%;
      border: 1px solid lightgray;
 }
+#headerContainer {
+    width:100%;
+    display:flex;
+    align-items:center;
+    padding: 0 5px 0 5px;
+}
+#headerContainer > * {
+  margin:5px;
+}
 #splitpane {
     position: relative;
     height : 80%;
@@ -80,11 +89,9 @@
 
 .App-header {
     background-color: #282c34;
-     padding: 5px;
      min-height: 8vh;
      display: flex;
-     flex-direction: column;
-     align-items: left; /* center; */
+     align-items: center; /* center; */
      justify-content: left; /*center;*/
      color: white;
      font-size: calc(9px + 2vmin);
@@ -132,8 +139,9 @@
     right: 105px;
 }
 #runButton {
-    position: absolute;
-    right: 41px;
+  height:60%;
+    /* position: absolute; */
+    /* right: 41px; */
  }
 .settingsDialog {
     width: 95%;
@@ -141,19 +149,26 @@
     height: 95%;
     /*max-height: 95%; */
 }
+#appControlContainer {
+  display:flex;
+  flex-direction:column;
+}
+#appControlContainer > * {
+  margin:0;
+}
 #settings {
-    position: absolute;
-    right : 3px;
-    top : 11px;
+    /* position: absolute; */
+    /* right : 3px; */
+    /* top : 11px; */
+}
+#answerViewer {
+  /* position: absolute; */
+  /* right : 3px; */
+  /* top: 40px; */
 }
 #mainLegend {
   border-top:1px solid rgb(200,200,200);
   border-bottom:1px solid rgb(200,200,200);
-}
-#answerViewer {
-    position: absolute;
-    right : 3px;
-    top: 40px;
 }
 .App-link {
   color: #61dafb;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -30,11 +30,12 @@
     /* bottom: 0px; */
     overflow:auto;
     height:100%;
-    border-left: 2px solid rgb(60,60,60);
+    border-left: 2px solid rgb(166, 226, 46);
 
 }
 #info > ul {
   margin:5px !important;
+  margin-bottom: 12.5px !important;
 }
 
 .tableView {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -35,7 +35,6 @@
 }
 #toolbar {
     background-color:rgba(39, 40, 34, 1);
-    border-right:2px solid rgb(80, 86, 70);
     width:auto;
 }
 #info {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -46,6 +46,27 @@
     background-color:rgba(30,30,30, 1);
     width:auto;
 }
+#schemaBanner {
+    background-color: rgb(30, 30, 30);
+    border-bottom: 4px solid rgb(50, 50, 50);
+    /* font-weight: bold; */
+    position: relative;
+    padding: 12.5px;
+    /* text-align: center; */
+    font-style: italic;
+    font-size: 18px;
+    color: rgb(235, 235, 235);
+}
+#schemaViewToggleButtonContainer {
+  height:100%;
+  float:right;
+  /* top:0; */
+  /* right:12.5px; */
+  /* position:absolute; */
+  display:flex;
+  justify-content:center;
+  align-items:center;
+}
 #info {
     /* position: absolute; */
     background-color: rgb(39, 40, 34);
@@ -54,7 +75,6 @@
     height:100%;
     width:100%;
     border-left: 2px solid rgb(166, 226, 46);
-
 }
 #info > ul {
     margin:5px !important;

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -373,6 +373,11 @@ class App extends Component {
     this.setState({ schemaViewerEnabled : active }, () => {
       this._fgAdjustCharge (this.state.charge);
     });
+    if (this.state.objectViewerEnabled) {
+      let width = this._graphSplitPane.current.splitPane.offsetWidth;
+      this._graphSplitPane.current.setState({ draggedSize : width, pane1Size : width , position : width });
+      this._updateGraphSize(width);
+    }
   }
   /**
    * Set the navigation / selection mode.
@@ -791,7 +796,8 @@ class App extends Component {
         this.state.selectedLink !== null &&
 //        this.state.selectedLink.source !== link.source_id &&
 //        this.state.selectedLink.target !== link.target_id &&
-        this.state.selectMode)
+        this.state.selectMode &&
+        !this.state.navigateMode)
     {
       // Select the node.
       this.setState ((prevState, props) => ({
@@ -1344,33 +1350,32 @@ class App extends Component {
                     </div>
                   </div>
                   <div onContextMenu={this._handleContextMenu}>
-                      {this.state.schemaViewerEnabled ?
-                        (
-                          this._renderForceGraph (
-                            this.state.schema,
-                            {
-                            ref: (el) => {if (this.state.schemaViewerEnabled) this.fg = el;},
-                            nodeAutoColorBy: 'type',
-                            linkAutoColorBy: 'type'
+                    {this.state.schemaViewerEnabled ?
+                      (
+                        this._renderForceGraph (
+                          JSON.parse(JSON.stringify(this.state.schema)),
+                          {
+                          ref: (el) => {if (this.state.schemaViewerEnabled) this.fg = el;},
 
-                            // Kind of hacky - in essense, every time the active graph changes, the d3 alpha decay forces are reapplied.
-                            // This detects if this is the first render and, if so, it allows the alpha decay forces to be applied to the graph.
-                            // Additionally, the react-force-graph does not seem to like it when you pass in a property as undefined.
-                            // Therefore, the spread operator is used here to conditionally add properties to the object without having to pass in a property as undefined
-                            // Commented out because it breaks charge. Needs to somehow reset graph when graph type changes, but also needs to retain auto color property.
-                            // ...(this.state.schema.nodes.some(n => n.index !== undefined) || this.state.schema.links.some(l => l.index !== undefined) ? {d3AlphaDecay: 1} : {})
-                          })
-                        )
-                      :
-                        (
-                          this._renderForceGraph (this.state.graph, {
-                            ref: (el) => {if (!this.state.schemaViewerEnabled) this.fg = el;}
+                          // Kind of hacky - in essense, every time the active graph changes, the d3 alpha decay forces are reapplied.
+                          // This detects if this is the first render and, if so, it allows the alpha decay forces to be applied to the graph.
+                          // Additionally, the react-force-graph does not seem to like it when you pass in a property as undefined.
+                          // Therefore, the spread operator is used here to conditionally add properties to the object without having to pass in a property as undefined
+                          // Commented out because it breaks charge. Needs to somehow reset graph when graph type changes, but also needs to retain auto color property.
+                          // ...(this.state.schema.nodes.some(n => n.index !== undefined) || this.state.schema.links.some(l => l.index !== undefined) ? {d3AlphaDecay: 1} : {})
+                        })
+                      )
+                    :
+                      (
+                        this._renderForceGraph (
+                          JSON.parse(JSON.stringify(this.state.graph)), {
+                          ref: (el) => {if (!this.state.schemaViewerEnabled) this.fg = el;}
 
-                            // Refer to similar block in the above schema graph for a reference to what atrocious things are occuring here
-                            // ...(this.state.graph.nodes.some(n => n.index !== undefined) || this.state.graph.links.some(l => l.index !== undefined) ? {d3AlphaDecay: 1} : {})
-                          })
-                        )
-                      }
+                          // Refer to similar block in the above schema graph for a reference to what atrocious things are occuring here
+                          // ...(this.state.graph.nodes.some(n => n.index !== undefined) || this.state.graph.links.some(l => l.index !== undefined) ? {d3AlphaDecay: 1} : {})
+                        })
+                      )
+                    }
                     <ContextMenu id={this._contextMenuId} ref={this._contextMenu}/>
                   </div>
                 </div>

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -8,6 +8,7 @@ import JSONTree from 'react-json-tree';
 import logo from './static/images/tranql.png'; // Tell Webpack this JS file uses this image
 import { contextMenu } from 'react-contexify';
 import { IoIosSettings, IoIosPlayCircle } from 'react-icons/io';
+import { FaMousePointer, FaBan, FaArrowsAlt } from 'react-icons/fa';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import ReactTable from "react-table";
 //import Tooltip from 'rc-tooltip';
@@ -19,6 +20,7 @@ import Cache from './Cache.js';
 import Actor from './Actor.js';
 import AnswerViewer from './AnswerViewer.js';
 import Legend from './Legend.js';
+import { Toolbar, Tool, ToolGroup } from './Toolbar.js';
 import Message from './Message.js';
 import Chain from './Chain.js';
 import ContextMenu from './ContextMenu.js';
@@ -195,6 +197,24 @@ class App extends Component {
 
       // Legend component
       hiddenTypes: [],
+
+      // Tools for the toolbar component
+      tools: [
+        <ToolGroup>
+          <Tool name="Select" description="Select a node or link" callback={(e) => console.log("foobar",e)}>
+            <FaMousePointer/>
+          </Tool>
+          <Tool name="Testing" description="Testing tool" callback={(e) => console.log("test",e)}>
+            <FaBan/>
+          </Tool>
+          <Tool name="Navigate" description="Navigate along the graph" callback={(e) => console.log("navi",e)}>
+            <FaArrowsAlt/>
+          </Tool>
+        </ToolGroup>,
+        <Tool name="NavigateTest" description="Navigate along the graph" callback={(e) => console.log("other",e)}>
+          <FaArrowsAlt/>
+        </Tool>
+      ],
 
       // Settings modal
       showSettingsModal : false,
@@ -1114,32 +1134,35 @@ class App extends Component {
                   id="mainLegend"
                   render={this.state.colorGraph}/>
           <div id="graph"></div>
-          <SplitPane split="vertical"
-                     defaultSize={this.state.graphWidth}
-                     minSize={0}
-                     allowResize={Object.keys(this.state.selectedNode).length !== 0}
-                     maxSize={document.body.clientWidth}
-                     style={{"backgroundColor":"black"}}
-                     ref={this._graphSplitPane}
-                     onDragFinished={(width) => this._updateGraphSplitPaneResize()}
-          >
-            <div onContextMenu={this._handleContextMenu}>
-              { this._renderForceGraph () }
-              <ContextMenu id={this._contextMenuId} ref={this._contextMenu}/>
-            </div>
-            <div id="info">
-              <JSONTree
-              shouldExpandNode={(key,data,level) => level === 1}
-              hideRoot={true}
-              theme={
-                {scheme:"monokai", author:"wimer hazenberg (http://www.monokai.nl)", base00:"#272822",base01:"#383830",base02:"#49483e",base03:"#75715e",base04:"#a59f85",
-                base05:"#f8f8f2",base06:"#f5f4f1",base07:"#f9f8f5", base08:"#f92672",base09:"#fd971f",base0A:"#f4bf75",base0B:"#a6e22e",base0C:"#a1efe4",base0D:"#66d9ef",
-                base0E:"#ae81ff",base0F:"#cc6633"}
-              }
-              invertTheme={false}
-              data={this.state.selectedNode} />
-            </div>
-          </SplitPane>
+          <div id="viewContainer">
+            <Toolbar id="toolbar" tools={this.state.tools}/>
+            <SplitPane split="vertical"
+                       defaultSize={this.state.graphWidth}
+                       minSize={0}
+                       allowResize={Object.keys(this.state.selectedNode).length !== 0}
+                       maxSize={document.body.clientWidth}
+                       style={{"backgroundColor":"black","position":"static"}}
+                       ref={this._graphSplitPane}
+                       onDragFinished={(width) => this._updateGraphSplitPaneResize()}
+            >
+              <div onContextMenu={this._handleContextMenu}>
+                { this._renderForceGraph () }
+                <ContextMenu id={this._contextMenuId} ref={this._contextMenu}/>
+              </div>
+              <div id="info">
+                <JSONTree
+                shouldExpandNode={(key,data,level) => level === 1}
+                hideRoot={true}
+                theme={
+                  {scheme:"monokai", author:"wimer hazenberg (http://www.monokai.nl)", base00:"#272822",base01:"#383830",base02:"#49483e",base03:"#75715e",base04:"#a59f85",
+                  base05:"#f8f8f2",base06:"#f5f4f1",base07:"#f9f8f5", base08:"#f92672",base09:"#fd971f",base0A:"#f4bf75",base0B:"#a6e22e",base0C:"#a1efe4",base0D:"#66d9ef",
+                  base0E:"#ae81ff",base0F:"#cc6633"}
+                }
+                invertTheme={false}
+                data={this.state.selectedNode} />
+              </div>
+            </SplitPane>
+          </div>
         </div>
         <div id='next'/>
       </div>

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -1353,7 +1353,7 @@ class App extends Component {
                     {this.state.schemaViewerEnabled ?
                       (
                         this._renderForceGraph (
-                          JSON.parse(JSON.stringify(this.state.schema)),
+                          this.state.schema,
                           {
                           ref: (el) => {if (this.state.schemaViewerEnabled) this.fg = el;},
 
@@ -1368,7 +1368,7 @@ class App extends Component {
                     :
                       (
                         this._renderForceGraph (
-                          JSON.parse(JSON.stringify(this.state.graph)), {
+                          this.state.graph, {
                           ref: (el) => {if (!this.state.schemaViewerEnabled) this.fg = el;}
 
                           // Refer to similar block in the above schema graph for a reference to what atrocious things are occuring here

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -341,7 +341,9 @@ class App extends Component {
 
     }
     this.setState ({
-      navigateMode: ! this.state.navigateMode
+      navigateMode: ! this.state.navigateMode,
+      selectedNode: {},
+      selectedLink: {}
     });
   }
   /**
@@ -414,8 +416,13 @@ class App extends Component {
         nodes : [],
         links : []
       },
-      hiddenTypes : []
+      hiddenTypes : [],
+      selectedNode: {},
+      selectedLink: {}
     });
+    let width = this._graphSplitPane.current.splitPane.offsetWidth;
+    this._updateGraphSize(width);
+    this._graphSplitPane.current.setState({ draggedSize : width, pane1Size : width , position : width });
     //localStorage.setItem ("code", JSON.stringify (this.state.code));
     // First check if it's in the cache.
     //var cachePromise = this._cache.read (this.state.code);
@@ -662,7 +669,7 @@ class App extends Component {
         selectedNode : { link : link.origin }
       }));
       let width = this._graphSplitPane.current.splitPane.offsetWidth * (1/2);
-      this._updateGraphSize(width) // Sets info element to containerSize - size
+      this._updateGraphSize(width); // Sets info element to containerSize - size
       this._graphSplitPane.current.setState({ draggedSize : width, pane1Size : width , position : width });
 
 
@@ -1110,6 +1117,7 @@ class App extends Component {
           <SplitPane split="vertical"
                      defaultSize={this.state.graphWidth}
                      minSize={0}
+                     allowResize={Object.keys(this.state.selectedNode).length !== 0}
                      maxSize={document.body.clientWidth}
                      style={{"backgroundColor":"black"}}
                      ref={this._graphSplitPane}
@@ -1121,6 +1129,7 @@ class App extends Component {
             </div>
             <div id="info">
               <JSONTree
+              shouldExpandNode={(key,data,level) => level === 1}
               hideRoot={true}
               theme={
                 {scheme:"monokai", author:"wimer hazenberg (http://www.monokai.nl)", base00:"#272822",base01:"#383830",base02:"#49483e",base03:"#75715e",base04:"#a59f85",

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -49,9 +49,6 @@ const spinnerStyleOverride = css`
     display: block;
     margin: 4 auto;
     border-color: red;
-    position: absolute;
-    right: 207px;
-    top: 9px;
 `;
 
 /**
@@ -1114,8 +1111,8 @@ class App extends Component {
       <div className="App" id="AppElement">
         <ReactTooltip place="left"/>
         <header className="App-header" >
-          <div>
-            TranQL {this._renderModal () }
+          <div id="headerContainer">
+            <p style={{display:"inline-block",flex:1}}>TranQL</p> {this._renderModal () }
             <AnswerViewer show={true} ref={this._answerViewer} />
             <Message show={false} ref={this._messageDialog} />
             <GridLoader
@@ -1138,8 +1135,10 @@ class App extends Component {
                     color="success" onClick={this._executeQuery}>
               Run
             </Button>
-            <IoIosSettings data-tip="Configure application settings" id="settings" className="App-control" onClick={this._handleShowModal} />
-            <IoIosPlayCircle data-tip="Answer Viewer - see each answer, its graph structure, links, knowledge source and literature provenance" id="answerViewer" className="App-control" onClick={this._handleShowAnswerViewer} />
+            <div id="appControlContainer">
+              <IoIosSettings data-tip="Configure application settings" id="settings" className="App-control" onClick={this._handleShowModal} />
+              <IoIosPlayCircle data-tip="Answer Viewer - see each answer, its graph structure, links, knowledge source and literature provenance" id="answerViewer" className="App-control" onClick={this._handleShowAnswerViewer} />
+            </div>
           </div>
         </header>
         <div>

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -200,6 +200,9 @@ class App extends Component {
 
       // Tools for the toolbar component
       tools: [
+        <Tool name="NavigateTest" description="Navigate along the graph" callback={(e) => console.log("other",e)}>
+          <FaArrowsAlt/>
+        </Tool>,
         <ToolGroup>
           <Tool name="Select" description="Select a node or link" callback={(e) => console.log("foobar",e)}>
             <FaMousePointer/>
@@ -210,10 +213,7 @@ class App extends Component {
           <Tool name="Navigate" description="Navigate along the graph" callback={(e) => console.log("navi",e)}>
             <FaArrowsAlt/>
           </Tool>
-        </ToolGroup>,
-        <Tool name="NavigateTest" description="Navigate along the graph" callback={(e) => console.log("other",e)}>
-          <FaArrowsAlt/>
-        </Tool>
+        </ToolGroup>
       ],
 
       // Settings modal

--- a/web/src/Cache.js
+++ b/web/src/Cache.js
@@ -11,26 +11,26 @@ class Cache extends Component {
     this.db = new Dexie('TranQLClientCache');
     // Declare tables, IDs and indexes
     this.db.version(1).stores({
-      cache: '++id, name, &key, graph, type'
+      cache: '++id, name, &key, graph',
+      schema: '++id, graph'
     });
     this.write = this.write.bind (this);
   }
-  async write (data) {//key, data) {
+  async write (table, data) {
     // Write cache.
-    return await this.db.cache.put (data);
+    return await this.db[table].put (data);
   }
-  async read (type, key) {
-    return await this.db.cache
-    .where ('type')
-    .equals (type)
-    .and ((item) => item.key === key)
+  async read (table, key) {
+    return await this.db[table]
+    .where('key')
+    .equals (key)
     .toArray();
   }
-  async get (id, callback) {
-    return await this.db.cache.get (id, callback);
+  async get (table, id, callback) {
+    return await this.db[table].get (id, callback);
   }
   async clear () {
-    return await this.db.cache.clear ();
+    return await Object.values(this.db).forEach((table) => table.clear ());
   }
 }
 

--- a/web/src/Cache.js
+++ b/web/src/Cache.js
@@ -11,7 +11,7 @@ class Cache extends Component {
     this.db = new Dexie('TranQLClientCache');
     // Declare tables, IDs and indexes
     this.db.version(1).stores({
-      cache: '++id, name, &key, graph'
+      cache: '++id, name, &key, graph, type'
     });
     this.write = this.write.bind (this);
   }
@@ -19,10 +19,11 @@ class Cache extends Component {
     // Write cache.
     return await this.db.cache.put (data);
   }
-  async read (key) {
-    return await this.db.cache 
-    .where('key')
-    .equals (key)
+  async read (type, key) {
+    return await this.db.cache
+    .where ('type')
+    .equals (type)
+    .and ((item) => item.key === key)
     .toArray();
   }
   async get (id, callback) {

--- a/web/src/Cache.js
+++ b/web/src/Cache.js
@@ -12,7 +12,7 @@ class Cache extends Component {
     // Declare tables, IDs and indexes
     this.db.version(1).stores({
       cache: '++id, name, &key, graph',
-      schema: '++id, graph'
+      schema: '&id, graph'
     });
     this.write = this.write.bind (this);
   }

--- a/web/src/Cache.js
+++ b/web/src/Cache.js
@@ -30,7 +30,7 @@ class Cache extends Component {
     return await this.db[table].get (id, callback);
   }
   async clear () {
-    return await Object.values(this.db).forEach((table) => table.clear ());
+    return await this.db.tables.forEach((table) => table.clear ());
   }
 }
 

--- a/web/src/Legend.css
+++ b/web/src/Legend.css
@@ -32,7 +32,7 @@
 
 .TypeButton:hover, .TypeButton.active, .TypeButton:hover.active {
   border-color:rgb(100,100,100);
-  color:rgb(245,245,245) !important;
+  color:rgb(100,100,100) !important;
 }
 
 .TypeButton.focus, .TypeButton:focus {

--- a/web/src/Legend.css
+++ b/web/src/Legend.css
@@ -44,15 +44,6 @@
   border-radius:0;
 }
 
-/* Change the 'border-like' color of an active TypeButton */
-/* .TypeButton:not(:disabled):not(.disabled).active,
-.TypeButton:not(:disabled):not(.disabled):active,
-.show>.TypeButton.dropdown-toggle{
-  color: black !important;
-  background-color: black !important;
-  border-color: black !important;
-} */
-
 .legend-vis-control {
   /* Using margin for consistency */
   margin-top:7px;

--- a/web/src/Legend.css
+++ b/web/src/Legend.css
@@ -2,6 +2,18 @@
   width: 100%;
   background-color:rgb(230,230,230);
 }
+.Legend[data-closed="true"] {
+  padding:5px;
+  display:flex;
+  align-items:center;
+  justify-content:flex-end;
+}
+
+.legendHeader {
+  flex-grow:1;
+  margin:0;
+  font-size:16px;
+}
 
 /* Default = flexbox, but this prevents the ButtonGroup from being multiple lines, which is the default behavior. */
 .btn-group {
@@ -54,7 +66,9 @@
   /* Since the icon is overlayed over the force graph when collapsed, set z-index to higher than force graph's (auto) */
   z-index: 1 !important;
 }
-
+.legend-vis-control-open {
+  font-size:24px;
+}
 .graph-element-type-container {
   padding:5px 5px 5px 7.5px;
 }

--- a/web/src/Legend.js
+++ b/web/src/Legend.js
@@ -226,12 +226,13 @@ class Legend extends Component {
     }
     if (this.state.collapse) {
       return (
-          <div id={this.props.id} className="Legend">
+          <div id={this.props.id} className="Legend" data-closed={true}>
+            {/*<h6 className="legendHeader">Legend</h6>*/}
             <ReactTooltip place="left"/>
             <IoIosArrowDropdownCircle data-tip="Open legend"
-                                      className="legend-vis-control"
+                                      className="legend-vis-control-open"
                                       onClick={(e) => this.setState({ collapse : false })}
-                                      color="rgba(220,220,220,1)"
+                                      color="rgba(40,40,40,1)"
             />
           </div>
       )

--- a/web/src/Legend.js
+++ b/web/src/Legend.js
@@ -51,7 +51,6 @@ class TypeButtonGroup extends React.Component {
     let newValue = value[value.length-1];
     let newState = this.state.value.slice();
     let turnedOn = false;
-    console.log(this.state.value,newValue.type);
     this.state.value.forEach((value,i) => {
       let type = value;
       if (type === newValue.type) {
@@ -77,7 +76,6 @@ class TypeButtonGroup extends React.Component {
           this.props.types.map((typeData,n) => {
             // How to generate unique id??
             let checked = this.state.value.every(val => val !== typeData.type);
-            // console.log(this.state.value,typeData.type,checked);
             let data = {
               type: typeData.type,
               quantity: typeData.quantity,
@@ -145,6 +143,7 @@ class TypeButton extends Component {
 class Legend extends Component {
   /**
    * Constructs React.Component with arguments `props` and `context`
+   *
    * @param {Object} props - React component properties
    * @param {Boolean} props.render - If false, component will return null in `render` method
    * @param {Object} props.typeMappings - Type mappings of each graph element type (nodes/links)
@@ -210,19 +209,10 @@ class Legend extends Component {
     return newMappings;
   }
 
-  /*
-  TODO:
-
-    (medium) ask about nodes having multiple types and if they should hide if any types are filtered or if all are filtered
-
-  */
-
   render() {
     //Move some of this logic elsewhere? Not really supposed to have any in render, but I don't know where to properly place it
 
     let typeMappings = this.props.typeMappings;
-
-    console.log(typeMappings);
 
     let sortedMappings = this._sortMappings(typeMappings);
 
@@ -236,6 +226,7 @@ class Legend extends Component {
     if (this.state.collapse) {
       return (
           <div id={this.props.id} className="Legend">
+            <ReactTooltip place="left"/>
             <IoIosArrowDropdownCircle data-tip="Open legend"
                                       className="legend-vis-control"
                                       onClick={(e) => this.setState({ collapse : false })}
@@ -257,7 +248,6 @@ class Legend extends Component {
       // });
       return (
         <div id={this.props.id} className="Legend">
-          <ReactTooltip place="left"/>
           {/*+2px in margin-top is because of 2px border*/}
           <IoIosArrowDropupCircle onClick={(e) => this.setState({ collapse : true })} data-tip="Close legend" className="legend-vis-control"/>
           {

--- a/web/src/Legend.js
+++ b/web/src/Legend.js
@@ -168,9 +168,10 @@ class Legend extends Component {
    * @param {Object} typeMappings - Mappings of types of nodes and links to their quantities and colors
    * @param {Object} typeMappings.nodes - Node object mappings with structure `type` => {`color`,`quantity`}
    * @param {Object} typeMappings.links - Link object mappings with structure `type` => {`color`,`quantity`}
-   *
+   * @param {String[]} hiddenTypes - Array of strings specifying the hidden types contained within the typeMappings.
+   *    This allows the Legend to make each type button the correct state (on/off) when rendering.
    * @returns {Object} - New sorted mapping object with zipped structure
-   *   {`nodes` : [{"type":`type`,"color":`color`,"quantity":`quantity`},...], `links` : [{"type":`type`,"color":`color`,"quantity",`quantity`},...]}
+   *    {`nodes` : [{"type":`type`,"color":`color`,"quantity":`quantity`},...], `links` : [{"type":`type`,"color":`color`,"quantity",`quantity`},...]}
    * @private
    */
   _sortMappings(typeMappings) {

--- a/web/src/Legend.js
+++ b/web/src/Legend.js
@@ -239,7 +239,7 @@ class Legend extends Component {
             <IoIosArrowDropdownCircle data-tip="Open legend"
                                       className="legend-vis-control"
                                       onClick={(e) => this.setState({ collapse : false })}
-                                      color="rgba(255,255,255,.5)"
+                                      color="rgba(220,220,220,1)"
             />
           </div>
       )

--- a/web/src/Legend.js
+++ b/web/src/Legend.js
@@ -79,6 +79,7 @@ class TypeButtonGroup extends React.Component {
             let data = {
               type: typeData.type,
               quantity: typeData.quantity,
+              actualQuantity: typeData.hasOwnProperty('actualQuantity') ? typeData.actualQuantity : 0,
               color: typeData.color
             };
             return <TypeButton value={data} active={checked} data={data} key={n} />
@@ -130,7 +131,8 @@ class TypeButton extends Component {
         value={this.props.value}
         size="sm"
         className="TypeButton">
-        {this.props.active ? <b>{TypeButton.adjustTitle(this.props.data.type)}</b> : TypeButton.adjustTitle(this.props.data.type)} <b>({this.props.data.quantity})</b>
+        {this.props.active ? <b>{TypeButton.adjustTitle(this.props.data.type)}</b> : TypeButton.adjustTitle(this.props.data.type)}
+        {this.props.active ? <b>({this.props.data.actualQuantity}/{this.props.data.quantity})</b> : "("+this.props.data.actualQuantity+"/"+this.props.data.quantity+")"}
       </ToggleButton>
     );
   }

--- a/web/src/Render.js
+++ b/web/src/Render.js
@@ -141,7 +141,6 @@ class SourceDatabaseFilter extends Actor {
 }
 class LegendFilter extends Actor {
   handle (message, context) {
-    console.log(context);
     var links = [];
     var nodes = [];
     /*
@@ -155,7 +154,7 @@ class LegendFilter extends Actor {
           }
       }
     */
-    message.typeMappings = {
+    let typeMappings = {
       nodes:{},
       links:{}
     };
@@ -164,11 +163,11 @@ class LegendFilter extends Actor {
       elements.forEach(element => {
         if (typeof element.type === "string")  element.type = [element.type];
         element.type.forEach(type => {
-          if (message.typeMappings[elementType].hasOwnProperty(type)) {
-            message.typeMappings[elementType][type].quantity++;
+          if (typeMappings[elementType].hasOwnProperty(type)) {
+            typeMappings[elementType][type].quantity++;
           }
           else {
-            message.typeMappings[elementType][type] = {
+            typeMappings[elementType][type] = {
               color: null,
               quantity: 1
             };
@@ -183,24 +182,28 @@ class LegendFilter extends Actor {
     ];
 
     // (Zip structure ( [type, {quantity:x}] ))
-    for (let elementType in message.typeMappings) {
-      let sortedTypes = Object.entries(message.typeMappings[elementType]).sort((a,b) => b[1].quantity-a[1].quantity);
+    for (let elementType in typeMappings) {
+      let sortedTypes = Object.entries(typeMappings[elementType]).sort((a,b) => b[1].quantity-a[1].quantity);
       sortedTypes.forEach(obj => {
         let type = obj[0];
         let color = colors.length > 0 ? colors.shift() : '#ffffff';
         // Set colors of each type
-        message.typeMappings[elementType][type].color = color;
+        typeMappings[elementType][type].color = color;
       });
     }
-    message.graph.nodes.forEach(node => {node.color = message.typeMappings.nodes[node.type[0]].color});
-    message.graph.links.forEach(link => {link.color = message.typeMappings.links[link.type].color});
+    message.graph.nodes.forEach(node => {node.color = typeMappings.nodes[node.type[0]].color});
+    message.graph.links.forEach(link => {link.color = typeMappings.links[link.type].color});
 
+    if (!message.hasOwnProperty('hiddenTypes')) {
+      // If this is the first time the message is processed by the render chain, give it the hiddenTypes property.
+      message.hiddenTypes = [];
+    }
 
     // Filter nodes that are hidden (NodeFilter source)
     // Couldn't understand the NodeFilter and LinkFilter code so I didn't bother trying to write this feature into the filters with an additional argument or something and reinvoke it
     var nodes = message.graph.nodes.reduce ((acc, node) => {
       //keep node if all of its types are visible
-      if (node.type.every(type => context.hiddenTypes.indexOf(type) === -1)) {
+      if (node.type.every(type => message.hiddenTypes.indexOf(type) === -1)) {
         acc.push (node);
       }
       return acc;
@@ -235,7 +238,7 @@ class LegendFilter extends Actor {
       links: message.graph.links.reduce (function (result, link) {
         link.type = typeof link.type === "string" ? [link.type] : link.type;
         link.type.forEach(type => {
-          if (context.hiddenTypes.indexOf(type) === -1) {
+          if (message.hiddenTypes.indexOf(type) === -1) {
             result.push (link);
             if (! node_ref.includes (link.source)) {
               node_ref.push (link.source);
@@ -252,7 +255,9 @@ class LegendFilter extends Actor {
           result.push (node);
         }
         return result;
-      }, [])
+      }, []),
+      typeMappings: typeMappings,
+      hiddenTypes: message.hiddenTypes
     };
   }
 }

--- a/web/src/Render.js
+++ b/web/src/Render.js
@@ -186,7 +186,6 @@ class LegendFilter extends Actor {
     for (let elementType in message.typeMappings) {
       let sortedTypes = Object.entries(message.typeMappings[elementType]).sort((a,b) => b[1].quantity-a[1].quantity);
       sortedTypes.forEach(obj => {
-        console.log(obj);
         let type = obj[0];
         let color = colors.length > 0 ? colors.shift() : '#ffffff';
         // Set colors of each type

--- a/web/src/Render.js
+++ b/web/src/Render.js
@@ -259,7 +259,6 @@ class LegendFilter extends Actor {
     };
     for (let elementType in message.graph) {
       let elements = message.graph[elementType];
-      console.log(elements,typeof elements,elements.forEach);
       elements.forEach(element => {
         if (typeof element.type === "string")  element.type = [element.type];
         element.type.forEach(type => {

--- a/web/src/Render.js
+++ b/web/src/Render.js
@@ -256,9 +256,24 @@ class LegendFilter extends Actor {
         }
         return result;
       }, []),
-      typeMappings: typeMappings,
-      hiddenTypes: message.hiddenTypes
     };
+    for (let elementType in message.graph) {
+      let elements = message.graph[elementType];
+      console.log(elements,typeof elements,elements.forEach);
+      elements.forEach(element => {
+        if (typeof element.type === "string")  element.type = [element.type];
+        element.type.forEach(type => {
+          if (typeMappings[elementType][type].hasOwnProperty('actualQuantity')) {
+            typeMappings[elementType][type].actualQuantity++;
+          }
+          else {
+            typeMappings[elementType][type].actualQuantity = 1;
+          }
+        });
+      });
+    }
+    message.graph.typeMappings = typeMappings;
+    message.graph.hiddenTypes = message.hiddenTypes;
   }
 }
 export {

--- a/web/src/Render.js
+++ b/web/src/Render.js
@@ -11,7 +11,7 @@ class RenderInit extends Actor {
             type : node.type,
             radius : 9,
             name: node.name,
-            origin: node        // keep the orgin node.
+            origin: node        // keep the origin node.
           }; }),
         links: message.knowledge_graph.edges.map(function (edge, index) {
           var weight = Math.round (edge.weight * 100) / 100;

--- a/web/src/Toolbar.css
+++ b/web/src/Toolbar.css
@@ -1,7 +1,7 @@
 .Toolbar {
   height:100%;
   width:auto;
-  border-right:2px solid rgb(80, 86, 70);
+  border-right:5px solid rgb(50,50,50);
 }
 
 
@@ -9,7 +9,7 @@
   position:relative;
   white-space:nowrap;
   padding:5px;
-  border-radius:2px;
+  border-radius:3px;
   display:flex; /* Inline-block doesn't seem to work to fit to contents when icon is contained, but flex does */
 }
 
@@ -27,7 +27,7 @@
 }
 
 .Tool[data-active-tool="true"] {
-  background-color:rgba(20,20,20,1);
+  background-color:rgba(0,0,0,1);
 }
 
 /* Lots of styling to create a triangle in the bottom-right corner */
@@ -63,18 +63,22 @@
   flex-direction:column;
 }
 
+
 .select-menu-tool {
   white-space:nowrap;
   display:inline-block;
   width:100%;
-  font-size:13px;
+  font-size:14px;
   color:rgba(220,220,220,.9);
-  padding:4px 3px 4px 3px;
+  padding:5px;
   user-select:none;
   -webkit-user-select:none;
   -moz-user-select:none;
   -o-user-select:none;
   -ms-user-select:none;
+}
+
+.select-menu-tool[data-active-tool="true"] {
 }
 
 .select-menu-tool:hover {
@@ -108,7 +112,7 @@
 
 .tool-container {
   /* Type of container that each tool and tool group is wrapped inside of */
-  margin:6px;
+  margin:3px;
   display:flex;
   justify-content:center;
 }

--- a/web/src/Toolbar.css
+++ b/web/src/Toolbar.css
@@ -1,0 +1,106 @@
+.Toolbar {
+  display:grid;
+  grid-template-columns:auto auto;
+  grid-auto-rows:min-content;
+  height:100%;
+  width:auto;
+  padding:6px;
+}
+
+.Tool {
+  position:relative;
+  white-space:nowrap;
+  padding:5px;
+  border-radius:2px;
+  display:flex; /* Inline-block doesn't seem to work to fit to contents when icon is contained, but flex does */
+}
+
+.Tool:active {
+  background-color:rgba(30,30,30,1);
+}
+
+.Tool:active > * {
+  color:rgba(180,180,180,.9);
+}
+
+.Tool:hover {
+  background-color:rgba(35,35,35,1);
+
+}
+
+.Tool[data-active-tool="true"] {
+  background-color:rgba(20,20,20,1);
+}
+
+/* Lots of styling to create a triangle in the bottom-right corner */
+.tool-group > .Tool::after {
+  content:'';
+  position:absolute;
+  bottom:0;
+  right:0;
+  transform:translate(-1px,-1px); /* Padding/margin does not work */
+  border-radius: 0;
+  border-color:transparent;
+  border-style:solid;
+  border-width:2px;
+  border-right-color:rgba(220,220,220,.9);
+  border-bottom-color:rgba(220,220,220,.9);
+}
+
+/* Change color of corner when active to match background */
+.Tool[data-tool-group="true"]:active::after {
+  border-right-color:rgba(130,130,130,.9);
+  border-bottom-color:rgba(130,130,130,.9);
+}
+
+.select-menu {
+  position:absolute;
+  z-index:1;
+  background-color:rgb(30,30,30);
+  top:0;
+  left:100%;
+  margin-left:2px;
+  border:1px solid rgba(200,200,200,1);
+  display:flex;
+  flex-direction:column;
+}
+
+.select-menu-tool {
+  white-space:nowrap;
+  display:inline-block;
+  width:100%;
+  font-size:13px;
+  color:rgba(220,220,220,.9);
+  padding:4px 3px 4px 3px;
+  user-select:none;
+  -webkit-user-select:none;
+  -moz-user-select:none;
+  -o-user-select:none;
+  -ms-user-select:none;
+}
+
+.select-menu-tool:hover {
+  background-color:rgba(50,50,50,1);
+}
+
+.select-menu-tool:active {
+  background-color:rgba(45,45,45,1);
+}
+
+.select-menu-tool > * {
+  font-size:16px;
+  color:rgba(220,220,220,.9);
+}
+
+.Tool > * {
+  /* I'm not sure this will support all of the icon toolkits in react-icons (only tested on FontAwesome and IonIcons) */
+  font-size:16px;
+  color:rgba(220,220,220,.9); /* Easier on the eyes and just generally looks better */
+}
+
+.tool-container {
+  /* Type of container that each tool and tool group is wrapped inside of */
+  margin:6px;
+  display:flex;
+  justify-content:center;
+}

--- a/web/src/Toolbar.css
+++ b/web/src/Toolbar.css
@@ -1,11 +1,9 @@
 .Toolbar {
-  display:grid;
-  grid-template-columns:auto auto;
-  grid-auto-rows:min-content;
   height:100%;
   width:auto;
-  padding:6px;
+  border-right:2px solid rgb(80, 86, 70);
 }
+
 
 .Tool {
   position:relative;
@@ -59,8 +57,8 @@
   background-color:rgb(30,30,30);
   top:0;
   left:100%;
-  margin-left:2px;
-  border:1px solid rgba(200,200,200,1);
+  margin-left:3.5px;
+  border:1px solid rgba(150,150,150,1);
   display:flex;
   flex-direction:column;
 }
@@ -96,6 +94,16 @@
   /* I'm not sure this will support all of the icon toolkits in react-icons (only tested on FontAwesome and IonIcons) */
   font-size:16px;
   color:rgba(220,220,220,.9); /* Easier on the eyes and just generally looks better */
+}
+
+.toolbar-header {
+}
+
+.toolbar-content {
+  padding:6px;
+  display:grid;
+  grid-template-columns:auto auto;
+  grid-auto-rows:min-content;
 }
 
 .tool-container {

--- a/web/src/Toolbar.css
+++ b/web/src/Toolbar.css
@@ -2,6 +2,8 @@
   height:100%;
   width:auto;
   border-right:5px solid rgb(50,50,50);
+  display:flex;
+  flex-direction:column;
 }
 
 
@@ -104,10 +106,26 @@
 }
 
 .toolbar-content {
+  flex-grow:1;
   padding:6px;
   display:grid;
   grid-template-columns:auto auto;
   grid-auto-rows:min-content;
+}
+
+.toolbar-button-container {
+  position:relative;
+  flex-grow:0;
+}
+.toolbar-button-container::after {
+  content:'';
+  position:absolute;
+  bottom:0;
+  left: 5%;
+  width:90%;
+  height:2px;
+  background-color:rgba(70,70,70,1);
+  /* border-bottom:2px solid rgba(50,50,50,1); */
 }
 
 .tool-container {

--- a/web/src/Toolbar.js
+++ b/web/src/Toolbar.js
@@ -98,7 +98,7 @@ export class ToolGroup extends Component {
         {
           this.state.children.map((tool,index) => {
             return (
-              <div key={index} className="select-menu-tool" onClick={() => this._selectActive(index,true)}>
+              <div key={index} className="select-menu-tool" data-active-tool={this.state.activeTool === index} onClick={() => this._selectActive(index,true)}>
                 {/* Clone the icon of the tool (children is a component when only one child exists) */}
                 {React.cloneElement(tool.props.children)} {tool.props.description}
               </div>
@@ -166,7 +166,7 @@ export class Tool extends Component {
    *
    * @param {Object} props - Properties of the Tool
    * @param {string} props.name - Name of the tool
-   * @param {string} props.description - Description of the tool (keep it short)
+   * @param {string} props.description - Description of the tool (keep it short). Only functional when contained in a ToolGroup.
    * @param {onClick} props.callback - Callback invoked on click
    * @param {Component} props.children - Icon of the child (e.g. <IoIosSettings />)
    */
@@ -200,6 +200,7 @@ export class Tool extends Component {
       <div className="Tool"
            onMouseUp={this.props.onMouseUp || (() => {this.setActive(true);})}
            onMouseDown={this.props.onMouseDown}
+           title={this.props.name}
            data-active-tool={this.state.active}>
         {
           /* this.props.children is a single component (not an array) when only one child is present */

--- a/web/src/Toolbar.js
+++ b/web/src/Toolbar.js
@@ -1,0 +1,260 @@
+import React, { Component } from 'react';
+import './Toolbar.css'
+
+/**
+ * Component allowing for the easy multifunctionality of a single tool slot (name is fairly misleading)
+ *    Acts as a singular tool, which then can open a dropdown when held down which allows the user to replace the active tool with others contained within the ToolGroup
+ *    As a visual explanation: The marquee group in Adobe Photoshop, which contains multiple different types of marquee tools (the default being the rectangular marquee).
+ *    (Ex: https://i.gyazo.com/0bd4d63abd26eb8538e38836bb6be22e.png)
+ */
+export class ToolGroup extends Component {
+  /**
+   * Constructs a new ToolGroup component
+   *
+   * @param {Object} props - Properties of the ToolGroup
+   * @param {Tool[]} props.children - Tools that are contained within the ToolGroup.
+   *    The default will be the first child listed. The rest will also be listed in the dropdown according to their order
+   */
+   constructor(props) {
+     super(props);
+
+     this._selectActive = this._selectActive.bind(this);
+     this._leave = this._leave.bind(this);
+     this._showSelectMenu = this._showSelectMenu.bind(this);
+     this.setActive = this.setActive.bind(this);
+
+     // For some reason children isn't an array when there is only one child
+     let children = (!Array.isArray(this.props.children)) ? [this.props.children] : this.props.children;
+
+     if (children.length === 0) throw new Error("ToolGroup must contain at minimum one Tool");
+     children = children.map((comp, index) => {
+       // There is a better way to do this in React 0.14+, but I could not get it to work.
+       if (comp.type !== Tool) {
+         throw new Error("ToolGroup must only contain components of type Tool, not type '"+(typeof comp.type === 'string' ? comp.type : comp.type.name)+"'");
+       }
+       let callback = comp.props.callback;
+       return React.cloneElement(comp, {
+         onMouseDown: (e) => {
+           e.preventDefault();
+           this._selectActive(index);
+         },
+         onMouseUp: (e) => {
+           this._leave(index);
+         },
+         toolbarCallback:this.props.toolbarCallback,
+         key:index,
+         ref:React.createRef()
+       });
+     });
+
+     this.state = {
+       selectMenuHover: false,
+       selectMenu: null,
+       children: children
+     };
+   }
+
+   componentDidMount() {
+     this._activeTool = 0;
+   }
+
+   setActive(active) {
+     /* ToolGroup class needs to be able to function exactly as if it is an instance of a Tool */
+     this.state.children.forEach((tool,i) => {
+       tool.ref.current.state.active && tool.ref.current.setActive(active);
+     });
+   }
+
+   get _activeTool() {
+     return this.state.children[this.state.activeTool];
+   }
+
+   set _activeTool(index) {
+     this.setState(prevState => {
+       return {activeTool:index};
+     }, () => {
+       this.state.children.forEach((tool,i) => {
+         tool.ref.current.setActive(i === index);
+       });
+     });
+   }
+
+   _showSelectMenu() {
+     const leaveCallback = () => {
+       this.setState(prevState => {
+         return {
+           selectMenuHover: false,
+           selectMenu: null
+         };
+       });
+     }
+     let selectMenu = (
+       <div onMouseLeave={leaveCallback}
+            onMouseEnter={this.setState({selectMenuHover:true})}
+            className="select-menu"
+       >
+        {
+          this.state.children.map((tool, index) => {
+            return (
+              <div key={index} className="select-menu-tool" onClick={() => this._selectActive(index,true)}>
+                {/* Clone the icon of the tool (children is a component when only one child exists) */}
+                {React.cloneElement(tool.props.children)} {tool.props.description}
+              </div>
+            );
+          })
+        }
+       </div>
+     );
+     this.setState({ selectMenu : selectMenu });
+   }
+
+   _leave(index) {
+     if (this.state.selectMenu) {
+       if (!this.state.selectMenuHover) {
+         this.setState({
+           selectMenuHover: false,
+           selectMenu: null
+         });
+       }
+     }
+     else {
+       clearInterval(this.state.children[index].ref.current.holdTimeout);
+       this._activeTool = index;
+     }
+   }
+
+   _selectActive(index,selectMenu=false) {
+     let tool = this.state.children[index];
+     let active = this._activeTool === tool;
+     if (selectMenu) {
+       this._activeTool = index;
+       this.setState({ selectMenu: null, selectMenuHover: false});
+     }
+     else if (active) {
+       tool.ref.current.holdTimeout = setTimeout(() => {
+         this._showSelectMenu();
+       },500);
+     }
+   }
+
+   render() {
+     return (
+        <div className="tool-group" style={{position:"relative"}}>
+          {this._activeTool}
+          {this.state.selectMenu}
+          {/* This is really bad but they lose their refs when they're not rendered */}
+          <div style={{display:"none"}}>{this.state.children.map(tool => tool !== this._activeTool && tool)}</div>
+        </div>
+     );
+   }
+}
+
+/**
+ * @callback onClick
+ * @param {Object} clickEvent - The click event that is fired
+ */
+
+/**
+ * Component used to define, represent, and act as a tool in a Toolbar or ToolGroup component.
+ *
+ */
+export class Tool extends Component {
+  /**
+   * Constructs a new Tool component
+   *
+   * @param {Object} props - Properties of the Tool
+   * @param {string} props.name - Name of the tool
+   * @param {string} props.description - Description of the tool (keep it short)
+   * @param {onClick} props.callback - Callback invoked on click
+   * @param {Component} props.children - Icon of the child (e.g. <IoIosSettings />)
+   */
+  constructor(props) {
+    super(props);
+
+    if (this.props.children === undefined) throw new Error("Tool must contain icon component");
+    if (Array.isArray(this.props.children)) throw new Error("Tool must contain icon component as the only child");
+
+    this.state = {
+      active: false
+    };
+
+    // this.setActive = this.setActive.bind(this);
+  }
+
+  setActive(act) {
+    this.setState(prevState => {
+      if (act !== prevState.active) {
+        this.props.callback(act);
+        if (act) {
+          this.props.toolbarCallback(this);
+        }
+      }
+      return { active: act };
+    });
+  }
+
+  render() {
+    return (
+      <div className="Tool"
+           onMouseUp={this.props.onMouseUp || (() => {this.setActive(true);})}
+           onMouseDown={this.props.onMouseDown}
+           data-active-tool={this.state.active}>
+        {
+          /* this.props.children is a single component (not an array) when only one child is present */
+          this.props.children
+        }
+      </div>
+    );
+  }
+}
+
+/**
+ * Toolbar component that contains ToolGroup and Tool components.
+ */
+export class Toolbar extends Component {
+  /**
+   * Constructs a new Toolbar component
+   *
+   * @param {Object} props - Properties of toolbar
+   * @param {Tool[]} props.tools - Array of tool groups and tools contained within the toolbar.
+   *    NOTE: Tools are not required to be contained inside of ToolGroups, the name may be misleading. Make sure to check out what a ToolGroup actually does.
+   */
+  constructor(props) {
+    super(props);
+
+    this.setActiveTool = this.setActiveTool.bind(this);
+
+    this.state = {
+      tools: this.props.tools.map((tool,i) => {
+        return React.cloneElement(tool, {
+          toolbarCallback: this.setActiveTool,
+          ref:React.createRef()
+        });
+      }),
+    };
+
+  }
+
+  setActiveTool(tool) {
+    this.state.tools.forEach((tool2,i) => {
+      tool !== tool2.ref.current && tool2.ref.current.setActive(false);
+    });
+  }
+
+  render() {
+    return (
+      <div id={this.props.id} className="Toolbar">
+        {
+          this.state.tools.map((tool,i) => {
+            return (
+              <div key={i} className='tool-container'>
+                {tool}
+              </div>
+            )
+          })
+        }
+      </div>
+    )
+  }
+
+}

--- a/web/src/Toolbar.js
+++ b/web/src/Toolbar.js
@@ -237,6 +237,8 @@ export class Toolbar extends Component {
    * @param {Object} props - Properties of toolbar
    * @param {Tool[]} props.tools - Array of tool groups and tools contained within the toolbar.
    *    NOTE: Tools are not required to be contained inside of ToolGroups, the name may be misleading. Make sure to check out what a ToolGroup actually does.
+   * @param {Component[]} props.buttons - Array of components (icons) contained at the bottom of the toolbar.
+   *    The Toolbar does not modify these components in any way. It simply provides a container for them to be better placed within the larger document.
    * @param {int} [props.default=0] - Index in props.tools of the default active tool (its callback will be invoked to select it)
    */
   constructor(props) {
@@ -271,6 +273,17 @@ export class Toolbar extends Component {
     return (
       <div id={this.props.id} className="Toolbar">
         <div className="toolbar-header"></div>
+        <div className="toolbar-content toolbar-button-container">
+        {
+          this.props.buttons.map((button,i) => {
+            return (
+              <div key={i} className='tool-container'>
+              {button}
+              </div>
+            )
+          })
+        }
+        </div>
         <div className="toolbar-content">
           {
             this.state.tools.map((tool,i) => {


### PR DESCRIPTION
This PR:
- Reworks the object viewer into a split pane with the graph
- Adds a toolbar which contains both the navigate and select tools, as well as a button container which contains the settings and answer viewer buttons. 
- Introduces async requests when querying services. From a data sample size of three on the default query regarding asthma with a maximum of 4 concurrent requests, this saw times improved on average by 1357% (avg. 120.98s to 8.91s).
- Adds graph charge force setter (previously fixed at -40). This allows for users to spread and condense the nodes by setting the charge to lower and higher values respectively.
- Adds schema rendering. The graph is now toggled between rendering the schema and rendering the query. The legend component, navigate and select tools, and charge setter also work on the schema.
- Legend now displays the actual number of nodes and links rendered after the legend filters out types, in addition to the pre-filtration numbers.
- Fixes banner styling.