### PR TITLE
Tranql varnish cache

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,21 +2,32 @@ version: "3"
 services:
   backplane:
     image: greentranslator/tranql-base
-    entrypoint: /usr/local/bin/gunicorn --workers=2 --bind=0.0.0.0:$BACKPLANE_PORT --name=backplane --timeout=600 tranql.backplane.server:app 
-#    volumes:
-#      - /Users/scox/dev/tranql:/tranql
+    entrypoint: /usr/local/bin/gunicorn --workers=2 --bind=0.0.0.0:$BACKPLANE_PORT --name=backplane --timeout=600 tranql.backplane.server:app
     ports:
       - "${BACKPLANE_PORT}:${BACKPLANE_PORT}"
   tranql:
     image: greentranslator/tranql-app
     environment:
-      - BACKPLANE=http://backplane:8099
+      - BACKPLANE=http://varnish_backplane:8080
+#      - BACKPLANE=http://backplane:8099  # Uncomment this line to avoid using cache.
       - APP_PORT
     entrypoint: /usr/local/bin/gunicorn --workers=2 --bind=0.0.0.0:$APP_PORT --name=tranql --timeout=600 tranql.api:app
-    volumes:
-      - /Users/scox/dev/tranql:/tranql
     ports:
       - "${APP_PORT}:${APP_PORT}"
+  varnish_frontend:
+    image: renciorg/tranql-varnish
+    container_name: tranql_frontend_cache
+    volumes:
+      - ../varnish-cache/frontend.config.vcl:/etc/varnish/default.vcl
+    ports:
+      - "8080:8080"
+  varnish_backplane:
+    image: renciorg/tranql-varnish
+    container_name: tranql_backplane_cache
+    volumes:
+      - ../varnish-cache/backplane.config.vcl:/etc/varnish/default.vcl
+    ports:
+      - "8081:8080"
 networks:
   default:
     external:

--- a/docker/tranql-varnish/Dockerfile
+++ b/docker/tranql-varnish/Dockerfile
@@ -1,0 +1,49 @@
+FROM debian:9.5
+# Varnish image with POST request caching
+# more info on varnish can be found at http://varnish-cache.org/
+
+ENV VARNISH_MOD=varnish-modules-0.15.0
+
+#  Install varnish 6.0 and dependencies
+RUN apt-get update -y
+RUN	apt-get install -y build-essential automake libtool curl git python-docutils wget
+RUN curl -s https://packagecloud.io/install/repositories/varnishcache/varnish60/script.deb.sh | bash
+RUN apt-get install -y varnish-dev
+
+# Build varnishMOD from source
+
+# Download and untar
+RUN wget https://download.varnish-software.com/varnish-modules/${VARNISH_MOD}.tar.gz
+RUN mkdir -p /tmp/varnish-mods
+RUN tar -xf ${VARNISH_MOD}.tar.gz -C /tmp/varnish-mods/
+RUN rm ${VARNISH_MOD}.tar.gz
+
+# Start building VarnishMOD
+
+WORKDIR /tmp/varnish-mods/${VARNISH_MOD}
+RUN ./configure && make &&  make check && make install
+WORKDIR /
+RUN rm -r /tmp/varnish-mods
+
+# Add cache post request .vcl config
+# Note: this is not the default config. Using this image still requires use to create a default.vcl in
+# /lib/varnish/default.vcl
+# The 'cache_post_requests.vcl' can be included in our default.vcl, to support caching post request.
+
+COPY cache_post_requests.vcl /etc/varnish/cache_post_requests.vcl
+
+# Set file permission for varnish user
+
+RUN mkdir -p /var/lib/varnish
+RUN chown varnish:varnish /var/lib/varnish
+
+# Activate the varnish user
+USER varnish
+
+# add entrypoint
+COPY docker-varnish-entrypoint.sh /
+
+ENTRYPOINT ["/docker-varnish-entrypoint.sh"]
+
+EXPOSE 8080 8443
+CMD []

--- a/docker/tranql-varnish/cache_post_requests.vcl
+++ b/docker/tranql-varnish/cache_post_requests.vcl
@@ -1,0 +1,39 @@
+vcl 4.0;
+import std;
+import bodyaccess;
+
+/**
+*  More on this logic can be found at https://info.varnish-software.com/blog/caching-post-requests-with-varnish
+*
+**/
+
+sub vcl_recv {
+    unset req.http.x-body-len;
+    if (req.method == "POST") {
+        set req.http.x-method = req.method;
+        // Request body more than 500KB will not be cached.
+        std.cache_req_body(500KB);
+        set req.http.x-body-len = bodyaccess.len_req_body();
+        return (hash);
+    }
+}
+
+sub vcl_hash {
+    if (req.method == "POST" && req.http.x-body-len) {
+        // Adding body to hash data via bodyaccess mod.
+        // Default hashing hashes url and path. This causes
+        // undesired effect on post caching. We need to hash body aswell.
+        bodyaccess.hash_req_body();
+    } else {
+        hash_data("");
+    }
+}
+
+sub vcl_backend_fetch {
+    // Varnish converts method to GET when fetching from backend by default
+    // This is to preserve the initial method coming from Client / Browser
+    if (bereq.http.x-method) {
+        set bereq.method = bereq.http.x-method;
+    }
+}
+

--- a/docker/tranql-varnish/docker-varnish-entrypoint.sh
+++ b/docker/tranql-varnish/docker-varnish-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+## Copied from https://github.com/varnish/docker-varnish/blob/master/stable/debian/docker-varnish-entrypoint
+
+
+
+
+set -e
+
+
+# this will check if the first argument is a flag
+# but only works if all arguments require a hyphenated flag
+# -v; -SL; -f arg; etc will work, but not arg1 arg2
+# running Varnish as non root user; Using port 8080 instead
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- varnishd -F -f /etc/varnish/default.vcl -a http=:8080,HTTP -a proxy=:8443,PROXY -s malloc,$VARNISH_SIZE "$@"
+fi
+
+exec "$@"

--- a/kubernetes/helm/.helmignore
+++ b/kubernetes/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kubernetes/helm/Chart.yaml
+++ b/kubernetes/helm/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: helm
+description: Helm chart for Tranql
+type: application
+# Chart Version
+version: 0.1.0
+# Using same version as the docker images at tranql/docker/bin/.ver
+appVersion: 0.26

--- a/kubernetes/helm/templates/tranql_backplane_deployment.yaml
+++ b/kubernetes/helm/templates/tranql_backplane_deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.tranql_backplane.deployment_name }}
+  labels:
+    service: {{ .Values.tranql_backplane.service_name }}
+    app: {{ .Values.tranql_backplane.app_name }}
+spec:
+  replicas: {{ .Values.tranql_backplane.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.tranql_backplane.app_name }}
+  template:
+    metadata:
+      labels:
+        app: tranql-backend
+    spec:
+      volumes:
+        - name: {{ .Values.tranql_logs.container_volume_name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.tranql_logs.pvc_name }}
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: tranql-backplane
+        image: {{ .Values.tranql_backplane.image }}:{{ .Values.tranql_backplane.image_tag }}
+        command: [ "/usr/local/bin/gunicorn", "--workers=2", "--timeout=600", "--access-logfile=$(ACCESS_LOG)", "--error-logfile=$(ERROR_LOG)", "--log-level=debug", "tranql.backplane.server:app" ]
+        ports:
+          - containerPort: {{ .Values.tranql_backplane.web_app_port }}
+            name: http
+        env:
+          - name: BACKPLANE_PORT
+            value: {{ .Values.tranql_backplane.wen_app_port | quote }}
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: ACCESS_LOG
+            value: "/var/nfs/tranql-backplane_access_log"
+          - name: ERROR_LOG
+            value: "/var/nfs/tranql-backplane_error_log"
+        volumeMounts:
+          - name: {{ .Values.tranql_logs.container_volume_name }}
+            mountPath: /var/nfs
+#        resources:
+#          requests:
+#            memory: 200Mi
+#          limits:
+#            memory: 1Gi
+      restartPolicy: {{ .Values.tranql_backplane.restart }}

--- a/kubernetes/helm/templates/tranql_backplane_service.yaml
+++ b/kubernetes/helm/templates/tranql_backplane_service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.tranql_backplane.service_name }}
+spec:
+
+#  type:	LoadBalancer
+#  loadBalancerIP: nnn.nn.nn.nnn
+  type: NodePort
+  selector:
+    app: {{ .Values.tranql_backplane.app_name }}
+  ports:
+  - protocol: TCP
+    port: {{ .Values.tranql_backplane.web_app_port }}
+    targetPort: {{ .Values.tranql_backplane.web_app_port }}

--- a/kubernetes/helm/templates/tranql_frontend_deployment.yaml
+++ b/kubernetes/helm/templates/tranql_frontend_deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.tranql_frontend.deployment_name }}
+  namespace: translator
+  labels:
+    service: {{ .Values.tranql_frontend.service_name }}
+    app: {{ .Values.tranql_frontend.app_name }}
+spec:
+  replicas: {{ .Values.tranql_frontend.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.tranql_frontend.app_name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.tranql_frontend.app_name }}
+    spec:
+      volumes:
+        - name: {{ .Values.tranql_logs.container_volume_name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.tranql_logs.pvc_name }}
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: tranql-app
+        image: {{ .Values.tranql_frontend.image }}:{{ .Values.tranql_frontend.image_tag }}
+        command: [ "/usr/local/bin/gunicorn", "--workers=2", "--bind=0.0.0.0:8001", "--timeout=600", "--access-logfile=$(ACCESS_LOG)", "--error-logfile=$(ERROR_LOG)", "--log-level=debug", "tranql.api:app" ]
+        ports:
+          - containerPort: {{ .Values.tranql_frontend.web_app_port }}
+            name: http
+        env:
+          - name: APP_PORT
+            value: {{ .Values.web_app_port | quote }}
+          - name: BACKPLANE
+            value: http://{{ .Values.tranql_backplane.service_name }}:{{ .Values.tranql_backplane.web_app_port }}
+          - name: USE_REGISTRY
+            value: {{ .Values.tranql_frontend.use_kp_registry | quote }}
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: ACCESS_LOG
+            value: "/var/nfs/tranql-frontend_access_log"
+          - name: ERROR_LOG
+            value: "/var/nfs/tranql-frontend_error_log"
+        volumeMounts:
+          - name: {{ .Values.tranql_logs.container_volume_name }}
+            mountPath: /var/nfs
+#        resources:
+#          requests:
+#            memory: 200Mi
+#          limits:
+#            memory: 1Gi
+      restartPolicy: {{ .Values.tranql_frontend.restart }}

--- a/kubernetes/helm/templates/tranql_frontend_deployment.yaml
+++ b/kubernetes/helm/templates/tranql_frontend_deployment.yaml
@@ -32,7 +32,12 @@ spec:
           - name: APP_PORT
             value: {{ .Values.web_app_port | quote }}
           - name: BACKPLANE
-            value: http://{{ .Values.tranql_backplane.service_name }}:{{ .Values.tranql_backplane.web_app_port }}
+            value:
+            {{- if eq .Values.enable_cache true}}
+             "http://{{ .Values.tranql_varnish.backplane.service_name }}:{{ .Values.tranql_varnish.backplane.port }}"
+            {{- else }}
+             "http://{{ .Values.tranql_backplane.service_name }}:{{ .Values.tranql_backplane.web_app_port }}"
+            {{ end }}
           - name: USE_REGISTRY
             value: {{ .Values.tranql_frontend.use_kp_registry | quote }}
           - name: POD_NAME

--- a/kubernetes/helm/templates/tranql_frontend_service.yaml
+++ b/kubernetes/helm/templates/tranql_frontend_service.yaml
@@ -4,9 +4,10 @@ metadata:
   name: {{ .Values.tranql_frontend.service_name }}
   namespace: translator
 spec:
-#  type:	LoadBalancer
-#  loadBalancerIP: nnn.nn.nn.nnn
-  type: NodePort
+  {{ if ne .Values.enable_cache true }}
+  type: LoadBalancer
+  loadBalancerIP: {{ .Values.loadBalancer_ip }}
+  {{ end }}
   selector:
     app: {{ .Values.tranql_frontend.app_name }}
   ports:

--- a/kubernetes/helm/templates/tranql_frontend_service.yaml
+++ b/kubernetes/helm/templates/tranql_frontend_service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.tranql_frontend.service_name }}
+  namespace: translator
+spec:
+#  type:	LoadBalancer
+#  loadBalancerIP: nnn.nn.nn.nnn
+  type: NodePort
+  selector:
+    app: {{ .Values.tranql_frontend.app_name }}
+  ports:
+  - protocol: TCP
+    port: {{ .Values.tranql_frontend.web_app_port }}
+    targetPort: {{ .Values.tranql_frontend.web_app_port }}

--- a/kubernetes/helm/templates/tranql_logs_volume.yaml
+++ b/kubernetes/helm/templates/tranql_logs_volume.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: PersistentVolume
+  metadata:
+    name: {{ .Values.tranql_logs.pv_name }}
+  spec:
+    accessModes:
+    - ReadWriteMany
+    capacity:
+      storage: {{ .Values.tranql_logs.storage_size }}
+    {{ if .Values.tranql_logs.storage_nfs_server }}
+    # For prod we can use nfs server
+    nfs:
+      server: {{ .Values.tranql_logs.storage_nfs_server }}
+      path: {{ .Values.tranql_logs.storage_path }}
+    {{ else }}
+    # For local set .Values.tranql_logs.storage_nfs_server to "" and mount host path
+    hostPath:
+      path: {{ .Values.tranql_logs.storage_path }}
+    {{ end }}
+    persistentVolumeReclaimPolicy: Retain
+    storageClassName: {{ .Values.tranql_logs.pv_name }}
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: {{ .Values.tranql_logs.pvc_name }}
+  spec:
+    accessModes:
+    - ReadWriteMany
+    resources:
+      requests:
+        storage: {{ .Values.tranql_logs.storage_size }}
+    storageClassName: {{ .Values.tranql_logs.pv_name }}
+kind: List

--- a/kubernetes/helm/templates/tranql_varnish_cache_deployment.yaml
+++ b/kubernetes/helm/templates/tranql_varnish_cache_deployment.yaml
@@ -1,0 +1,99 @@
+apiVersion: v1
+items:
+# Front end cache deployment
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: {{ .Values.tranql_varnish.frontend.deployment_name }}
+    labels:
+      service: {{ .Values.tranql_varnish.frontend.service_name }}
+      app: {{ .Values.tranql_varnish.frontend.app_name }}
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: {{ .Values.tranql_varnish.frontend.app_name }}
+    template:
+      metadata:
+        labels:
+          app: {{ .Values.tranql_varnish.frontend.app_name }}
+      spec:
+        initContainers:
+          - name: wait-for-tranql-frontend
+            image: busybox
+            args:
+              - /bin/sh
+              - -c
+              - >
+                set -x;
+                echo $(wget --spider -S "http://{{ .Values.tranql_frontend.service_name }}:{{ .Values.tranql_frontend.web_app_port }}/apidocs/" 2>&1 | grep "HTTP/" | awk '{print $2}');
+                while [ $(wget --spider -S "http://{{ .Values.tranql_frontend.service_name }}:{{ .Values.tranql_frontend.web_app_port }}/apidocs/" 2>&1 | grep "HTTP/" | awk '{print $2}') -ne 200 ]; do
+                  echo "Waiting for {{ .Values.tranql_frontend.service_name }}";
+                  sleep 1;
+                done;
+                echo "Connected ... ";
+        containers:
+          - name: {{ .Values.tranql_varnish.frontend.container_name }}
+            image: {{ .Values.tranql_varnish.image }}:{{ .Values.tranql_varnish.image_tag}}
+            ports:
+            - containerPort: {{ .Values.tranql_varnish.port }}
+              name: http
+            volumeMounts:
+              - name: vcl-config
+                mountPath: /etc/varnish/default.vcl
+                subPath: default.vcl
+        volumes:
+          - name: vcl-config
+            configMap:
+              name: {{ .Values.tranql_varnish.frontend.config_name }}
+              items:
+                - key: default_vcl
+                  path: default.vcl
+# -------------- Backplane cache deployment
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: {{ .Values.tranql_varnish.backplane.deployment_name }}
+    labels:
+      service: {{ .Values.tranql_varnish.backplane.service_name }}
+      app: {{ .Values.tranql_varnish.backplane.app_name }}
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: {{ .Values.tranql_varnish.backplane.app_name }}
+    template:
+      metadata:
+        labels:
+          app: {{ .Values.tranql_varnish.backplane.app_name }}
+      spec:
+        initContainers:
+          - name: wait-for-tranql-backplane
+            image: busybox
+            args:
+              - /bin/sh
+              - -c
+              - >
+                set -x;
+                while [$(wget --spider -S "http://{{ .Values.tranql_backplane.service_name }}:{{ .Values.tranql_backplane.web_app_port }}/apidocs/" 2>&1 | grep "HTTP/" | awk '{print $2}') -ne 200]; do
+                  echo "Waiting for {{ .Values.tranql_backplane.service_name}}";
+                  sleep 15;
+                done
+        containers:
+          - name: {{ .Values.tranql_varnish.backplane.container_name }}
+            image: {{ .Values.tranql_varnish.image }}:{{ .Values.tranql_varnish.image_tag}}
+            ports:
+            - containerPort: {{ .Values.tranql_varnish.port }}
+              name: http
+            volumeMounts:
+              - name: vcl-config
+                mountPath: /etc/varnish/default.vcl
+                subPath: default.vcl
+        volumes:
+          - name: vcl-config
+            configMap:
+              name: {{ .Values.tranql_varnish.backplane.config_name }}
+              items:
+                - key: default_vcl
+                  path: default.vcl
+kind: List

--- a/kubernetes/helm/templates/tranql_varnish_cache_service.yaml
+++ b/kubernetes/helm/templates/tranql_varnish_cache_service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+items:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: {{ .Values.tranql_varnish.frontend.service_name }}
+    spec:
+      type: NodePort
+      selector:
+        app: {{ .Values.tranql_varnish.frontend.app_name }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.tranql_varnish.port }}
+          targetPort: {{ .Values.tranql_varnish.port }}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: {{ .Values.tranql_varnish.backplane.service_name }}
+    spec:
+      type: NodePort
+      selector:
+        app: {{ .Values.tranql_varnish.backplane.app_name }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.tranql_varnish.port }}
+          targetPort: {{ .Values.tranql_varnish.port }}
+kind: List

--- a/kubernetes/helm/templates/tranql_varnish_cache_service.yaml
+++ b/kubernetes/helm/templates/tranql_varnish_cache_service.yaml
@@ -5,12 +5,16 @@ items:
     metadata:
       name: {{ .Values.tranql_varnish.frontend.service_name }}
     spec:
-      type: NodePort
+      {{ if eq .Values.enable_cache true}}
+      type: LoadBalancer
+      loadBalancerIP: {{ .Values.loadBalancer_ip }}
+      {{ end }}
       selector:
         app: {{ .Values.tranql_varnish.frontend.app_name }}
       ports:
         - protocol: TCP
-          port: {{ .Values.tranql_varnish.port }}
+          # use tranql frontend port if load cache is enable so we don't maintain two ports for loadbalancer
+          port: {{ if .Values.enable_cache }}{{ .Values.tranql_frontend.web_app_port }}{{ else }}{{ .Values.tranql_varnish.port }}{{ end }}
           targetPort: {{ .Values.tranql_varnish.port }}
   - apiVersion: v1
     kind: Service

--- a/kubernetes/helm/templates/varnish_cache.configmap.yaml
+++ b/kubernetes/helm/templates/varnish_cache.configmap.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: {{ .Values.tranql_varnish.frontend.config_name }}
+    data:
+      default_vcl:
+        vcl 4.0;
+        include "cache_post_requests.vcl";
+        backend default {
+        .host = "{{ .Values.tranql_frontend.service_name}}";
+        .port = "{{ .Values.tranql_frontend.web_app_port }}";
+        .probe = {
+          .url = "/apidocs/";
+          .timeout = 60s;
+          .interval = 5s;
+          .window = 5;
+          .threshold = 3;
+            }
+          }
+        /* set cache hit and miss indicator header */
+        sub vcl_recv {
+          unset req.http.x-cache-info;
+        }
+        sub vcl_hit {
+          set req.http.x-cache-info = "hit";
+        }
+        sub vcl_miss {
+          set req.http.x-cache-info = "miss";
+        }
+        sub vcl_deliver {
+          set req.http.x-cache-info = req.http.x-cache-info;
+        }
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: {{ .Values.tranql_varnish.backplane.config_name }}
+    data:
+      default_vcl:
+        vcl 4.0;
+        include "cache_post_requests.vcl";
+        backend default {
+          .host = "{{ .Values.tranql_backplane.service_name}}";
+          .port = "{{ .Values.tranql_backplane.web_app_port }}";
+          .probe = {
+            .url = "/apidocs/";
+            .timeout = 60s;
+            .interval = 5s;
+            .window = 5;
+            .threshold = 3;
+            }
+          }
+        /* set cache hit and miss indicator header */
+        sub vcl_recv {
+          unset req.http.x-cache-info;
+        }
+        sub vcl_hit {
+          set req.http.x-cache-info = "hit";
+        }
+        sub vcl_miss {
+          set req.http.x-cache-info = "miss";
+        }
+        sub vcl_deliver {
+          set req.http.x-cache-info = req.http.x-cache-info;
+        }
+kind: List

--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -49,3 +49,12 @@ tranql_varnish:
     config_name: tranql-backplane-cache-config
     container_name: tranql-varnish-backplane-container
 
+
+# the following values will be used to select the entry point from a loadbalancer
+# if enable cache is true varnish frontend cache will be the entry point
+# else tranql_frontend will be the entrypoint
+# and also enable_cache false will make sure that tranql_frontend is routing
+# directly to tranql-backplane and not through backplane cache proxy
+enable_cache: false
+loadBalancer_ip: nnn.nnn.nnn.nnn
+loadBalancer_port: xxxx

--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -1,0 +1,51 @@
+
+## Values for tranql frontend
+tranql_frontend:
+  image: renciorg/tranql-app
+  image_tag: latest
+  deployment_name: tranql-frontend-deployment
+  service_name: tranql-frontend-service
+  app_name: tranql_frontend
+  replicas: 1
+  web_app_port: "8001"
+  restart: "Always"
+  # Comment the line below to disable registry
+  use_kp_registry: true
+
+## Values for tranql backplane
+tranql_backplane:
+  image: renciorg/tranql-base
+  image_tag: latest
+  deployment_name: tranql-backend-deployment
+  service_name: tranql-backend-service
+  app_name: tranql-backend
+  replicas: 1
+  web_app_port: "8099"
+
+### Values for log persistence
+tranql_logs:
+  pv_name: tranql-logs-pv
+  pvc_name: tranql-logs-pvc
+  container_volume_name: tranql-logs-volume
+  storage_size: 1Gi
+#  storage_nfs_server: "stars-k.nfs.edc.renci.org"
+  storage_path: "/opt/tranql/logs"
+
+### Varnish cache configurations
+tranql_varnish:
+  image: renciorg/tranql-varnish
+  image_tag: latest
+  port: 8080
+  frontend:
+    deployment_name: tranql-frontend-cache-dep
+    service_name: tranql-frontend-cache-service
+    app_name: tranql-frontend-cache
+    config_name: tranql-frontend-cache-config
+    container_name: tranql-varnish-frontend-container
+  backplane:
+    deployment_name: tranql-backplane-cache-dep
+    service_name: tranql-backplane-cache-service
+    app_name: tranql-backend-cache
+    config_name: tranql-backplane-cache-config
+    container_name: tranql-varnish-backplane-container
+

--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -55,6 +55,6 @@ tranql_varnish:
 # else tranql_frontend will be the entrypoint
 # and also enable_cache false will make sure that tranql_frontend is routing
 # directly to tranql-backplane and not through backplane cache proxy
-enable_cache: false
+enable_cache: true
 loadBalancer_ip: nnn.nnn.nnn.nnn
 loadBalancer_port: xxxx

--- a/varnish-cache/backplane.config.vcl
+++ b/varnish-cache/backplane.config.vcl
@@ -1,0 +1,15 @@
+// Add include to post request caching
+include "cache_post_requests.vcl";
+
+backend default {
+    .host = "backplane";
+    .port = "8099";
+    .probe = {
+        .url = "/apidocs/";
+        .timeout = 60s;
+        .interval = 5s;
+        .window = 5;
+        .threshold = 3;
+    }
+}
+

--- a/varnish-cache/frontend.config.vcl
+++ b/varnish-cache/frontend.config.vcl
@@ -1,0 +1,15 @@
+// Add include to post request caching
+include "cache_post_requests.vcl";
+
+backend default {
+    .host = "tranql";
+    .port="8001";
+    .probe = {
+        .url = "/apidocs/";
+        .timeout = 60s;
+        .interval = 5s;
+        .window = 5;
+        .threshold = 3;
+    }
+}
+


### PR DESCRIPTION
- New docker image for varnish supporting caching of post request, using request body to compute hash.
- Helm chart with toggle for cache enabling and disable 
