### PR TITLE
Missing edges and score

### DIFF
--- a/tranql/tranql_ast.py
+++ b/tranql/tranql_ast.py
@@ -839,9 +839,10 @@ class SelectStatement(Statement):
                             exists = True
                             break
                     if exists:
+                        id_1, id_2 = edge['id'], e['id']
                         light_merge(edge,e)
                         light_merge(e,edge)
-                        killed_edges.append ([e['id'], edge['id']])
+                        killed_edges.append ([id_2, id_1])
                     else:
                         merged_edges.append (e)
 


### PR DESCRIPTION
After the recent changes on Knowledge map merge, scores were dropped. 
- This fix will put back in the score for a path if all the edge bindings and node bindings are present in a response that has been scored. 
Eg. if a binding  a-[e1]->b was given a score  and it ends up being merged and we have the following sets of paths 
a-[e1]->b->c , a-[e1]->b->d  then these are all given the score of the subpath (a-[e1]->b) .
- This also makes sure that edge ids are properly replaced in knowlege map if they are merged into an edge inside the knowledge graph. 