### PR TITLE
ICEES node synonymization.

### DIFF
--- a/tranql/backplane/server.py
+++ b/tranql/backplane/server.py
@@ -418,8 +418,85 @@ class ICEESClusterQuery(StandardAPIResource):
 
         with open ('icees.out.norm', 'w') as stream:
             json.dump (result, stream, indent=2)
-
+        result = self.synonymize(result)
         return self.response(result)
+
+    def synonymize(self, response):
+        knowledge_map_key = 'knowledge_map'
+        knowledge_graph_key = 'knowledge_graph'
+        query_graph_key = 'question_graph'
+        knowledge_graph = response[knowledge_graph_key]
+        knowledge_map = response[knowledge_map_key]
+        query_graph = response[query_graph_key]
+        base_url = 'https://nodenormalization-sri.renci.org'
+        supported_semantic_types = requests.get(
+            f'{base_url}/get_semantic_types'
+        ).json()['semantic_types']['types']
+        supported_q_ids = [x['id'] for x in query_graph['nodes'] if x['type'] in supported_semantic_types]
+        node_ids = set([x['id'] for x in knowledge_graph['nodes'] if x['type'] in supported_semantic_types])
+        chunk_size = 2000
+        curie_params = [f'curie={x}' for x in node_ids]
+        chunked_curie_params = [curie_params[start: start + chunk_size] for start in
+                                range(0, len(curie_params), chunk_size)]
+        response = {}
+        for chunk in chunked_curie_params:
+            r = {}
+            try:
+                full_url = f'{base_url}/get_normalized_nodes?{"&".join(chunk)}'
+                r = requests.get(full_url).json()
+                response.update(r)
+            except:
+                print(f'error making request {full_url}')
+
+        # replace supported types only careful not to replace other types like population_of_individual_organisms
+        # also keep track of things in supported type but failed to be synonymized (going to remove traces of these)
+        keep_nodes = [node['id'] for node in knowledge_graph['nodes'] if node['type'] not in supported_semantic_types or
+                      response.get(node['id'])]
+
+        filtered_nodes = list(filter(lambda node: node['id'] in keep_nodes, knowledge_graph['nodes']))
+        filtered_edges = list(filter(lambda edge: edge['source_id'] in keep_nodes and edge['target_id'] in keep_nodes,
+                                     knowledge_graph['edges']))
+        filtered_knowledge_map = list(filter(lambda answer: all([(answer['node_bindings'][key] in keep_nodes)
+                                                                 for key in answer['node_bindings']
+                                                                 if key in supported_q_ids]), knowledge_map))
+        # now we will assign names and main ids for all the ones we know mapped
+        for node in filtered_nodes:
+            # make sure we are not bumping into unsupported node types
+            if node['id'] in keep_nodes and node['type'] in supported_semantic_types:
+                node_data = response[node['id']]
+                norm_id = node_data['id']['identifier']
+                # default back to node name
+                norm_label = node_data['id'].get('label', '')
+                equivalent_ids = [eq['identifier'] for eq in node_data['equivalent_identifiers']]
+                if not norm_label:
+                    other_labels = [eq['label'] for eq in node_data['equivalent_identifiers'] if eq.get('label')]
+                    # pick first one else default back to the node's original
+                    norm_label = other_labels[0] if len(other_labels) else node['name']
+                node['id'] = norm_id
+                node['equivalent_identifiers'] = equivalent_ids
+                node['name'] = norm_label
+
+        for edge in filtered_edges:
+            if edge['source_id'] in response and response[edge['source_id']]:
+                edge['source_id'] = response[edge['source_id']]['id']['identifier']
+            if edge['target_id'] in response and response[edge['target_id']]:
+                edge['target_id'] = response[edge['target_id']]['id']['identifier']
+
+        for bindings in filtered_knowledge_map:
+            node_bindings = bindings['node_bindings']
+            for q_id in supported_q_ids:
+                if q_id in node_bindings:
+                    if node_bindings[q_id] in keep_nodes:
+                        node_bindings[q_id] = response[node_bindings[q_id]]['id']['identifier']
+
+        return {
+            query_graph_key: query_graph,
+            knowledge_graph_key: {
+                'nodes': filtered_nodes,
+                'edges': filtered_edges
+            },
+            knowledge_map_key: filtered_knowledge_map
+        }
 
     def compile_options (self, options):
         """ Compile input options into icees appropriate format. """

--- a/tranql/tests/test_backplane.py
+++ b/tranql/tests/test_backplane.py
@@ -2,7 +2,8 @@ import pytest
 import json
 from tranql.tests.util import assert_lists_equal, set_mock, ordered
 from tranql.backplane.server import api, app
-from tranql.backplane.server import RtxQuery
+from tranql.backplane.server import RtxQuery, ICEESClusterQuery
+import requests_mock
 
 @pytest.fixture
 def client():
@@ -117,3 +118,152 @@ def test_rtx_convert_curies(client):
 #         data=json.dumps()
 #         content_type='application/json'
 #     )
+
+def test_icees_synonymzation():
+    icees_response = {
+        'question_graph': {
+            'nodes': [
+                {'id': 'node_1', 'type': 'unsupported_type'},
+                {'id': 'node_2', 'type': 'supported_type_1'},
+                {'id': 'node_3', 'type': 'supported_type_2'}
+            ],
+            'edges': [
+                {'id': 'edge_1_2', 'source_id': 'node_1', 'target_type': 'node_2'},
+                {'id': 'edge_2_3', 'source_id': 'node_2', 'target_type': 'node_3'}
+            ]
+        },
+        'knowledge_graph': {
+            'nodes': [
+                {'id': 'curie:1', 'name': 'some_name', 'type': 'unsupported_type'},
+                {'id': 'curie:2', 'name': 'some_name', 'type': 'supported_type_1'},
+                {'id': 'curie:3', 'name': 'some_name', 'type': 'supported_type_1'},
+                {'id': 'curie:4', 'name': 'curie_4_name', 'type': 'supported_type_2'},
+                {'id': 'curie:5', 'name': 'curie_4_name', 'type': 'supported_type_2'}
+            ],
+            'edges': [
+                {'id': 'edge_curie:1_curie:2', 'source_id': 'curie:1', 'target_id': 'curie:2'},
+                {'id': 'edge_curie:2_curie:4', 'source_id': 'curie:2', 'target_id': 'curie:4'},
+                {'id': 'edge_curie:1_curie:3', 'source_id': 'curie:1', 'target_id': 'curie:3'},
+                {'id': 'edge_curie:3_curie:4', 'source_id': 'curie:3', 'target_id': 'curie:4'},
+                {'id': 'edge_curie:3_curie:5', 'source_id': 'curie:3', 'target_id': 'curie:5'}
+            ]
+        }
+    }
+    answer1, answer2, answer3 = \
+        {
+                'node_bindings': {'node_1': 'curie:1', 'node_2': 'curie:2', 'node_3': 'curie:4'},
+                'edge_bindings': {'edge_1_2': ['edge_curie:1_curie:2'], 'edge_3_4': ['edge_curie:2_curie:4']}
+        }\
+        ,{
+            'node_bindings': {'node_1': 'curie:1', 'node_2': 'curie:3', 'node_3': 'curie:4'},
+            'edge_bindings': {'edge_1_2': ['edge_curie:1_curie:2'], 'edge_3_4': ['edge_curie:3_curie:4']}
+        }\
+        ,{
+            'node_bindings': {'node_1': 'curie:1', 'node_2': 'curie:3', 'node_3': 'curie:5'},
+            'edge_bindings': {'edge_1_2': ['edge_curie:1_curie:3'], 'edge_3_4': ['edge_curie:3_curie:5']}
+        }
+    icees_response['knowledge_map'] = [answer1, answer2, answer3]
+
+    # For icees we will treat nodes in 3 categories
+    # nodes that are typed as types that are not supported by node normalization service
+    # nodes that are typed can be as ones that normalize and ones that don't
+    # our test is to make sure all nodes that are either normalizable or are don't have supported to be
+    # kept in the knowledge graph and nodes of supported type that donot normalize are dropped.
+
+    # mocking node norm get semantic types response
+    get_semantic_types_response = {
+      "semantic_types": {
+        "types": [
+            "supported_type_1",
+            "supported_type_2"
+        ]
+      }
+    }
+    # lets say curie:5 is unknown to the normalization service
+    # and curie:2 has its name updated
+    # and curie:3 has new id curie:33
+    # and curie:4 has same id but missing label in its normalized id but one eq has label
+
+    get_normalized_curies_response = {
+        "curie:2": {
+            "id": {
+                "identifier": "curie:2",
+                "label": "curie_2 has its name_updated"
+            },
+            "equivalent_identifiers": [
+                {"identifier": "curie:2", "label": "curie_2 has updated name"}
+            ]
+        },
+        "curie:3": {
+            "id": {
+                "identifier": "curie:33",
+                "label": "new label"
+            },
+            "equivalent_identifiers": [
+                {"identifier": "curie:3",  "label": "some_name"},
+                {"identifier": "curie:33", "label": "new label"}
+            ]
+        },
+        "curie:4": {
+            "id":{
+                "identifier": "curie:4",
+                "label": ""
+            },
+            "equivalent_identifiers": [
+                {"identifier": "curie:4", "label": ""},
+                {"identifier": "curie:44", "label": "updated name"}
+            ]
+        }
+    }
+    curie_params = '&'.join([f'curie={x["id"]}' for x in icees_response['knowledge_graph']['nodes']])
+    with requests_mock.mock() as mock_server:
+        mock_server.get(
+            'https://nodenormalization-sri.renci.org/get_semantic_types',
+            json=get_semantic_types_response
+        )
+
+        mock_server.get(
+            f'https://nodenormalization-sri.renci.org/get_normalized_nodes',
+            json=get_normalized_curies_response
+        )
+
+        icees_cluster_class = ICEESClusterQuery()
+
+        result = icees_cluster_class.synonymize(icees_response)
+
+        # we expect answer 3 to be gone so as node 5 and the edge 3->5 (edge_id : 'edge_curie:3_curie:5') to be removed
+        assert len(result['knowledge_graph']['edges']) == 4
+        assert 'edge_curie:3_curie:5' not in [edge['id'] for edge in result['knowledge_graph']['edges']]
+
+        assert len(result['knowledge_graph']['nodes']) == 4
+        node_ids = [node['id'] for node in result['knowledge_graph']['nodes']]
+        node_ids_expected = ['curie:1', 'curie:2', 'curie:33', 'curie:4']
+        assert 'curie:5' not in node_ids
+        for n_id in node_ids_expected:
+            assert n_id in node_ids
+
+        labels =  {node['id']: node['name'] for node in result['knowledge_graph']['nodes']}
+        expected_labels = {
+         'curie:1':'some_name',
+         'curie:2': 'curie_2 has its name_updated',
+         'curie:33': 'new label',
+         'curie:4': 'updated name'
+        }
+        for node_id in labels:
+            assert labels[node_id] == expected_labels[node_id]
+
+
+        # check if ids are updated in knowledge map
+
+        assert len(result['knowledge_map']) == 2
+        # we expect answer 1 not to change
+        assert answer1 in result['knowledge_map']
+        # we expect the other other to have curie:3 (bound to q_id node_2 to be updated)
+        next_answer = list(filter(lambda x: x != answer1, result['knowledge_map']))[0]
+        assert next_answer['node_bindings']['node_2'] == 'curie:33'
+        # assert the edge source and targe binding node_2 and node_3 is updated
+        edge_id = next_answer['edge_bindings']['edge_3_4']
+        edge = [e for e in result['knowledge_graph']['edges'] if e['id'] in edge_id][0]
+        assert edge['source_id'] == 'curie:33'
+
+


### PR DESCRIPTION
This addition will check if the nodes returned by icees are supported by node normalization service. If they are not supported (eg population_of_individual_organism) they are left alone. if they are supported but unknown by NN service , they are dropped from the answer set consequently knowledge graph edge and nodes are also updated not to contain them. 
If they are supported and NN knows of them , then ids and labels are updated with values from nn in the knowledge graph nodes and thier corresponding edge refreneces (source_id and/or target_id) are updated. 