### PR TITLE
Icees subtype fix

### DIFF
--- a/tranql/tests/test_backplane.py
+++ b/tranql/tests/test_backplane.py
@@ -136,7 +136,7 @@ def test_icees_synonymzation():
             'nodes': [
                 {'id': 'curie:1', 'name': 'some_name', 'type': 'unsupported_type'},
                 {'id': 'curie:2', 'name': 'some_name', 'type': 'supported_type_1'},
-                {'id': 'curie:3', 'name': 'some_name', 'type': 'supported_type_1'},
+                {'id': 'curie:3', 'name': 'some_name', 'type': 'supported_type_1_subtype_1'},
                 {'id': 'curie:4', 'name': 'curie_4_name', 'type': 'supported_type_2'},
                 {'id': 'curie:5', 'name': 'curie_4_name', 'type': 'supported_type_2'}
             ],
@@ -225,6 +225,18 @@ def test_icees_synonymzation():
         mock_server.get(
             f'https://nodenormalization-sri.renci.org/get_normalized_nodes',
             json=get_normalized_curies_response
+        )
+        mock_server.get(
+            f'https://bl-lookup-sri.renci.org/bl/supported_type_1/descendants?version=latest',
+            json = [
+                'supported_type_1_subtype_1'
+            ]
+        )
+        mock_server.get(
+            f'https://bl-lookup-sri.renci.org/bl/supported_type_2/descendants?version=latest',
+            json=[
+                'supported_type_2'
+            ]
         )
 
         icees_cluster_class = ICEESClusterQuery()


### PR DESCRIPTION
Icees on occasions returns types like `drug`, this is not returned in the list of supported node types from the node normailzation call  , https://nodenormalization-sri.renci.org/get_semantic_types. Inorder to make the list more comprehensive, we can levrage bl-lookup and find subtypes for the types node normalization service supports and use that as our filter to synonymize icees.