### PR TITLE
Web prefix for UI

### DIFF
--- a/docker/tranql-app/Dockerfile
+++ b/docker/tranql-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM renciorg/tranql-base:0.38
+FROM helxplatform/tranql-base
 
 WORKDIR /
 RUN apk add nodejs npm git

--- a/docker/tranql-app/Dockerfile
+++ b/docker/tranql-app/Dockerfile
@@ -1,9 +1,12 @@
-FROM helxplatform/tranql-base
+FROM renciorg/tranql-base:0.38
 
 WORKDIR /
 RUN apk add nodejs npm git
 WORKDIR /tranql/web
 RUN npm install
+# This lets us build index.html as a jinja template so static file references
+# such as css and js can be served properly when tranql is served behind proxy
+ENV PUBLIC_URL={{web_prefix}}
 RUN node --max-old-space-size=4000 ./node_modules/react-scripts/scripts/build.js
 RUN ln -s /tranql/web/build/static/ /tranql/tranql/static
 RUN apk del nodejs npm git

--- a/docker/tranql-base/Dockerfile
+++ b/docker/tranql-base/Dockerfile
@@ -1,12 +1,14 @@
 FROM python:3.7.3-alpine
 
+ARG BRANCH=master
+
 WORKDIR /
 
-RUN apk add git build-base linux-headers zeromq zeromq-dev
+RUN apk add git build-base linux-headers zeromq zeromq-dev libxslt-dev
 RUN pip install --upgrade pip
 #COPY requirements.txt ./
 #RUN pip install --no-cache-dir -r ./requirements.txt
-RUN git clone https://github.com/NCATS-Tangerine/tranql.git
+RUN git clone --single-branch --branch ${BRANCH}  https://github.com/NCATS-Tangerine/tranql.git
 #RUN grep -v mysql tranql/tranql/requirements.txt > r
 #RUN mv r tranql/tranql/requirements.txt
 RUN pip install --no-cache-dir -r tranql/tranql/requirements.txt

--- a/tranql/tranql_ast.py
+++ b/tranql/tranql_ast.py
@@ -637,7 +637,10 @@ class SelectStatement(Statement):
             import asyncio
             answer = asyncio.run(graph_interface.answer_trapi_question(question['message']['query_graph']))
             response = {'message': answer}
-
+            # Adds source db as reasoner attr in nodes and edges.
+            self.decorate_result(response['message'], {
+                "schema": self.service
+            })
         elif self.service == "/schema":
             result = self.execute_plan (interpreter)
         else:

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -94,7 +94,8 @@ class App extends Component {
       this.tranqlURL = "http://localhost:8001";
     }
     if(process.env.NODE_ENV === 'production') {
-      this.tranqlURL = window.location.origin;
+      // behind proxy this would treat the path used to load index.html as root
+      this.tranqlURL = window.location.href;
     }
     //this.tranqlURL = window.location.origin;
     //this.tranqlURL = "http://localhost:8001"; // dev only


### PR DESCRIPTION
PR is to fix 
* URL prefix for static assets:
    - After discussing this with Alexander, his apporach on app-store is a bit different where there is an extra layer of nginx serving static output of react builds.
   - In our case we don't have such proxy, the method i took was to generate index.html as a jinja template when tranql-app docker file npm builds. This way when flask serves that file it would append the configured web prefix for the static file refs. 
 * Reasoner(s) attribute :
     - In case of returning redis graph answers reasoner was not being added to nodes and edges. This PR fixes that
 * Docker files:
     - Tranql-base docker file was always being built off of master this parameterizes branch (as docker arg) and from our build yaml file in jenkins it  would control build branch 