### PR TITLE
Parameterizes docker file to support building a branch for CI/CD.

### DIFF
--- a/docker/tranql-app/Dockerfile
+++ b/docker/tranql-app/Dockerfile
@@ -1,4 +1,5 @@
-FROM helxplatform/tranql-base
+ARG BASE_IMAGE_VERSION=latest
+FROM helxplatform/tranql-base:${BASE_IMAGE_VERSION}
 
 WORKDIR /
 RUN apk add nodejs npm git


### PR DESCRIPTION
- tranql app image should base off of tranql-base image that is build for a specific branch. In CI these two images are built in seq, and tranql-base for develop will checkout develop ,
- by default tranql-base is built for master and tranql-app will build off of tranql-base:latest.