### PR TITLE
Plater version bump

### DIFF
--- a/tranql/requirements.txt
+++ b/tranql/requirements.txt
@@ -77,7 +77,7 @@ waitress==1.4.3
 wcwidth==0.1.7
 webencodings==0.5.1
 yarl==1.3.0
-PLATER-GRAPH==1.8
+PLATER-GRAPH==1.9
 git+git://github.com/patrickkwang/biolink-model-toolkit@master#egg=bmt
 git+https://github.com/ranking-agent/reasoner.git
 git+https://github.com/TranslatorSRI/reasoner-pydantic@v1.0.0#egg=reasoner-pydantic

--- a/tranql/requirements.txt
+++ b/tranql/requirements.txt
@@ -77,7 +77,7 @@ waitress==1.4.3
 wcwidth==0.1.7
 webencodings==0.5.1
 yarl==1.3.0
-PLATER-GRAPH==1.6
+PLATER-GRAPH==1.8
 git+git://github.com/patrickkwang/biolink-model-toolkit@master#egg=bmt
 git+https://github.com/ranking-agent/reasoner.git
 git+https://github.com/TranslatorSRI/reasoner-pydantic@v1.0.0#egg=reasoner-pydantic

--- a/tranql/tests/test_tranql.py
+++ b/tranql/tests/test_tranql.py
@@ -2147,6 +2147,7 @@ def test_redis_graph_cypher_options():
     redis_connection_params:
       host: localhost
       port: 6380"""
+
     mock_schema_yaml = {
         'schema':{
             'redis': {
@@ -2180,6 +2181,16 @@ def test_redis_graph_cypher_options():
     # we override the schema
     tranql = TranQL()
     with patch('yaml.safe_load', lambda x: copy.deepcopy(mock_schema_yaml)):
+        # clean up schema singleton
+        update_interval = 1
+        backplane = 'http://localhost:8099'
+        schema_factory = SchemaFactory(
+            backplane=backplane,
+            use_registry=False,
+            update_interval=update_interval,
+            create_new=True
+        )
+        tranql.schema = schema_factory.get_instance()
         with patch('PLATER.services.util.graph_adapter.GraphInterface.instance', graph_Inteface_mock(limit=20, skip=100, options_set=True)):
             ast = tranql.parse(
                 """

--- a/tranql/tests/test_tranql.py
+++ b/tranql/tests/test_tranql.py
@@ -2137,3 +2137,66 @@ def test_merged_node_ids_should_be_updated_in_knowledge_map():
     assert node_bindings_by_edge_kg_id['e_kg_id_22']['n1'] == ['kg_id_3']
     assert node_bindings_by_edge_kg_id['e_kg_id_2']['n0'] == ['kg_id_1']
     assert node_bindings_by_edge_kg_id['e_kg_id_2']['n1'] == ['kg_id_3']
+
+
+def test_redis_graph_cypher_options():
+    """doc: |
+      Roger is a knowledge graph built by aggregeting several kgx formatted knowledge graphs from several sources.
+    url: "redis:"
+    redis: true
+    redis_connection_params:
+      host: localhost
+      port: 6380"""
+    mock_schema_yaml = {
+        'schema':{
+            'redis': {
+                'doc': 'Red is a color but REDIS?',
+                'url': 'redis:',
+                'redis': True,
+                'redis_connection_params': {
+                    'host': 'local',
+                    'port': 6379
+                }
+            }
+        }
+    }
+
+    class graph_Inteface_mock:
+        def __init__(self, limit , skip, options_set):
+            self.limit = limit
+            self.skip  = skip
+            self.options_set = options_set
+
+        async def answer_trapi_question(self, message, options={}):
+            assert message
+            if self.options_set:
+                assert options
+                assert options['limit'] == self.limit
+                assert options['skip'] == self.skip
+            else:
+                assert options == {}
+            return {}
+
+    # we override the schema
+    tranql = TranQL()
+    with patch('yaml.safe_load', lambda x: copy.deepcopy(mock_schema_yaml)):
+        with patch('PLATER.services.util.graph_adapter.GraphInterface.instance', graph_Inteface_mock(limit=20, skip=100, options_set=True)):
+            ast = tranql.parse(
+                """
+                SELECT g1:gene->g2:gene
+                FROM 'redis:test'
+                where limit = 20 and skip = 100
+                """
+            )
+            select_statement = ast.statements[0]
+            select_statement.execute(interpreter=tranql)
+
+        with patch('PLATER.services.util.graph_adapter.GraphInterface.instance', graph_Inteface_mock(limit=20, skip=100, options_set=False)):
+            ast = tranql.parse(
+                """
+                SELECT g1:gene->g2:gene
+                FROM 'redis:test'
+                """
+            )
+            select_statement = ast.statements[0]
+            select_statement.execute(interpreter=tranql)

--- a/tranql/tranql_ast.py
+++ b/tranql/tranql_ast.py
@@ -516,7 +516,8 @@ class SelectStatement(Statement):
             edges[edge_id] = query_graph_edge
         question_graph = self.message(
             q_nodes = nodes,
-            q_edges = edges
+            q_edges = edges,
+            options= options
         )
         return question_graph
 
@@ -635,7 +636,15 @@ class SelectStatement(Statement):
             )
             question = self.generate_questions(interpreter)
             import asyncio
-            answer = asyncio.run(graph_interface.answer_trapi_question(question['message']['query_graph']))
+            options = question.get('options')
+            limit = options.get('limit', [])
+            skip = options.get('skip', [])
+            cypher_query_options = {}
+            if limit:
+                cypher_query_options['limit'] = limit[-1]
+            if skip:
+                cypher_query_options['skip'] = skip[-1]
+            answer = asyncio.run(graph_interface.answer_trapi_question(question['message']['query_graph'], options=cypher_query_options))
             response = {'message': answer}
             # Adds source db as reasoner attr in nodes and edges.
             self.decorate_result(response['message'], {


### PR DESCRIPTION
* Adds new version of plater where cypher is now using bound nodes as beginning of the cypher to decrease search space. https://github.com/RedisGraph/RedisGraph/issues/1727 . 
* Adds limit and skip paramters for tranql queries to be used as options for TRAPI message. 